### PR TITLE
Handle url encoded url segments

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -127,7 +127,7 @@ func buildCommonLogLine(req *http.Request, ts time.Time, status int, size int) s
 // status and size are used to provide the response HTTP status and size.
 func writeLog(w io.Writer, req *http.Request, ts time.Time, status, size int) {
 	line := buildCommonLogLine(req, ts, status, size) + "\n"
-	fmt.Fprintf(w, line)
+	fmt.Fprint(w, line)
 }
 
 // writeCombinedLog writes a log entry for req to w in Apache Combined Log Format.
@@ -136,7 +136,7 @@ func writeLog(w io.Writer, req *http.Request, ts time.Time, status, size int) {
 func writeCombinedLog(w io.Writer, req *http.Request, ts time.Time, status, size int) {
 	line := buildCommonLogLine(req, ts, status, size)
 	combinedLine := fmt.Sprintf("%s \"%s\" \"%s\"\n", line, req.Referer(), req.UserAgent())
-	fmt.Fprintf(w, combinedLine)
+	fmt.Fprint(w, combinedLine)
 }
 
 // CombinedLoggingHandler return a http.Handler that wraps h and logs requests to out in

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -92,6 +92,8 @@ func TestWriteLog(t *testing.T) {
 	}
 
 	// Request with an unauthorized user
+	req = newRequest("GET", "http://example.com")
+	req.RemoteAddr = "192.168.100.5"
 	req.URL.User = url.User("kamil")
 
 	buf.Reset()
@@ -99,6 +101,19 @@ func TestWriteLog(t *testing.T) {
 	log = buf.String()
 
 	expected = "192.168.100.5 - kamil [26/May/1983:03:30:45 +0200] \"GET / HTTP/1.1\" 401 500\n"
+	if log != expected {
+		t.Fatalf("wrong log, got %q want %q", log, expected)
+	}
+
+	// Request with url encoded parameters
+	req = newRequest("GET", "http://example.com/test?abc=hello%20world&a=b%3F")
+	req.RemoteAddr = "192.168.100.5"
+
+	buf.Reset()
+	writeLog(buf, req, ts, http.StatusOK, 100)
+	log = buf.String()
+
+	expected = "192.168.100.5 - - [26/May/1983:03:30:45 +0200] \"GET /test?abc=hello%20world&a=b%3F HTTP/1.1\" 200 100\n"
 	if log != expected {
 		t.Fatalf("wrong log, got %q want %q", log, expected)
 	}


### PR DESCRIPTION
Encoded URLs weren't being printed to the log properly.  ~~I think there's something odd about the Go fmt behaviour.~~ This is because the log string was being passed to `Fprintf` which treated it as a format string and got all confused about the %s in the URL.

Before:

```
GET /search?Hello%20World%20Testing
27.0.0.1 - - [03/Sep/2013:13:02:46 +1000] "GET /search?q=Hello%20World%T(MISSING)esting HTTP/1.1" 200 110
```

Which is wrong, obviously. It seems Go is interpreting the %s in the encoding as format instructions, not quite sure why. To fix this I replace any % with %% (the Go fmt escape for a literal %). 

After:

```
GET /search?Hello%20World%20Testing
27.0.0.1 - - [03/Sep/2013:13:02:46 +1000] "GET /search?q=Hello%20World%20Testing HTTP/1.1" 200 110
```

FYI: To get this working in tests properly, I had to change the use of `req.RequestURI` to `req.URL.RequestURI()` (which the Go docs recommend too) because the URL created in the test wasn't being used.
