### PR TITLE
Correctly parse remote address

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -10,6 +10,7 @@ package handlers
 import (
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"sort"
 	"strings"
@@ -110,8 +111,14 @@ func buildCommonLogLine(req *http.Request, ts time.Time, status int, size int) s
 		}
 	}
 
+	host, _, err := net.SplitHostPort(req.RemoteAddr)
+
+	if err != nil {
+		host = req.RemoteAddr
+	}
+
 	return fmt.Sprintf("%s - %s [%s] \"%s %s %s\" %d %d",
-		strings.Split(req.RemoteAddr, ":")[0],
+		host,
 		username,
 		ts.Format("02/Jan/2006:15:04:05 -0700"),
 		req.Method,

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -6,6 +6,7 @@ package handlers
 
 import (
 	"bytes"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -155,6 +156,34 @@ func TestWriteCombinedLog(t *testing.T) {
 	log = buf.String()
 
 	expected = "192.168.100.5 - kamil [26/May/1983:03:30:45 +0200] \"GET / HTTP/1.1\" 401 500 \"http://example.com\" " +
+		"\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) " +
+		"AppleWebKit/537.33 (KHTML, like Gecko) Chrome/27.0.1430.0 Safari/537.33\"\n"
+	if log != expected {
+		t.Fatalf("wrong log, got %q want %q", log, expected)
+	}
+
+	// Test with remote ipv6 address
+	req.RemoteAddr = "::1"
+
+	buf.Reset()
+	writeCombinedLog(buf, req, ts, http.StatusOK, 100)
+	log = buf.String()
+
+	expected = "::1 - kamil [26/May/1983:03:30:45 +0200] \"GET / HTTP/1.1\" 200 100 \"http://example.com\" " +
+		"\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) " +
+		"AppleWebKit/537.33 (KHTML, like Gecko) Chrome/27.0.1430.0 Safari/537.33\"\n"
+	if log != expected {
+		t.Fatalf("wrong log, got %q want %q", log, expected)
+	}
+
+	// Test remote ipv6 addr, with port
+	req.RemoteAddr = net.JoinHostPort("::1", "65000")
+
+	buf.Reset()
+	writeCombinedLog(buf, req, ts, http.StatusOK, 100)
+	log = buf.String()
+
+	expected = "::1 - kamil [26/May/1983:03:30:45 +0200] \"GET / HTTP/1.1\" 200 100 \"http://example.com\" " +
 		"\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) " +
 		"AppleWebKit/537.33 (KHTML, like Gecko) Chrome/27.0.1430.0 Safari/537.33\"\n"
 	if log != expected {


### PR DESCRIPTION
Use net.SplitHostPort to extract the host from (_net.Request).RemoteAddr,
rather than the naive string split, which fails on IPV6 addresses. If
net.SplitHostPort fails, use the raw value of (_http.Request).RemoteAddr for
the address field of log lines.

Test cases for IPV6 are added, with and without a port specified.
