### PR TITLE
Content-Type and HTTP method override handlers

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -322,3 +322,35 @@ func ContentTypeHandler(h http.Handler, contentTypes ...string) http.Handler {
 		http.Error(w, fmt.Sprintf("Unsupported content type %q; expected one of %q", r.Header.Get("Content-Type"), contentTypes), http.StatusUnsupportedMediaType)
 	})
 }
+
+const (
+	// HTTPMethodOverrideHeader is a commonly used
+	// http header to override a request method.
+	HTTPMethodOverrideHeader = "X-HTTP-Method-Override"
+	// HTTPMethodOverrideFormKey is a commonly used
+	// HTML form key to override a request method.
+	HTTPMethodOverrideFormKey = "_method"
+)
+
+// HTTPMethodOverrideHandler wraps and returns a http.Handler which checks for the X-HTTP-Method-Override header
+// or the _method form key, and overrides (if valid) request.Method with its value.
+//
+// This is especially useful for http clients that don't support many http verbs.
+// It isn't secure to override e.g a GET to a POST, so only POST requests are considered.
+// Likewise, the override method can only be a "write" method: PUT, PATCH or DELETE.
+//
+// Form method takes precedence over header method.
+func HTTPMethodOverrideHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" {
+			om := r.FormValue(HTTPMethodOverrideFormKey)
+			if om == "" {
+				om = r.Header.Get(HTTPMethodOverrideHeader)
+			}
+			if om == "PUT" || om == "PATCH" || om == "DELETE" {
+				r.Method = om
+			}
+		}
+		h.ServeHTTP(w, r)
+	})
+}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -258,3 +258,48 @@ func TestContentTypeHandler(t *testing.T) {
 		}
 	}
 }
+
+func TestHTTPMethodOverride(t *testing.T) {
+	var tests = []struct {
+		Method         string
+		OverrideMethod string
+		ExpectedMethod string
+	}{
+		{"POST", "PUT", "PUT"},
+		{"POST", "PATCH", "PATCH"},
+		{"POST", "DELETE", "DELETE"},
+		{"PUT", "DELETE", "PUT"},
+		{"GET", "GET", "GET"},
+		{"HEAD", "HEAD", "HEAD"},
+		{"GET", "PUT", "GET"},
+		{"HEAD", "DELETE", "HEAD"},
+	}
+
+	for _, test := range tests {
+		h := HTTPMethodOverrideHandler(okHandler)
+		reqs := make([]*http.Request, 0, 2)
+
+		rHeader, err := http.NewRequest(test.Method, "/", nil)
+		if err != nil {
+			t.Error(err)
+		}
+		rHeader.Header.Set(HTTPMethodOverrideHeader, test.OverrideMethod)
+		reqs = append(reqs, rHeader)
+
+		f := url.Values{HTTPMethodOverrideFormKey: []string{test.OverrideMethod}}
+		rForm, err := http.NewRequest(test.Method, "/", strings.NewReader(f.Encode()))
+		if err != nil {
+			t.Error(err)
+		}
+		rForm.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		reqs = append(reqs, rForm)
+
+		for _, r := range reqs {
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			if r.Method != test.ExpectedMethod {
+				t.Errorf("Expected %s, got %s", test.ExpectedMethod, r.Method)
+			}
+		}
+	}
+}


### PR DESCRIPTION
This is two handlers I use very often:
- `ContentTypeHandler`: checks a request's content type against a list of allowed content types. It responds a 415 if the check fails.
- `HTTPMethodOverrideHandler`: allows to change the request method using a header or a form key (originally contributed to [martini-contrib](https://github.com/martini-contrib/method)).
