### PR TITLE
Improve MethodHandler

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -14,41 +14,97 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
 	"unicode/utf8"
 )
 
-// MethodHandler is an http.Handler that dispatches to a handler whose key in the MethodHandler's
-// map matches the name of the HTTP request's method, eg: GET
+// MethodHandler is an http.Handler that dispatches to a handler whose field name matches
+// the name of the HTTP request's method, eg: GET
 //
-// If the request's method is OPTIONS and OPTIONS is not a key in the map then the handler
+// If the request's method is OPTIONS and Options is not set, then the handler
 // responds with a status of 200 and sets the Allow header to a comma-separated list of
 // available methods.
 //
 // If the request's method doesn't match any of its keys the handler responds with
-// a status of 406, Method not allowed and sets the Allow header to a comma-separated list
+// a status of 405, Method not allowed and sets the Allow header to a comma-separated list
 // of available methods.
-type MethodHandler map[string]http.Handler
+type MethodHandler struct {
+	Get, Head, Post, Put, Patch, Delete, Options http.Handler
+}
 
-func (h MethodHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	if handler, ok := h[req.Method]; ok {
-		handler.ServeHTTP(w, req)
-	} else {
-		allow := []string{}
-		for k := range h {
-			allow = append(allow, k)
+func (h MethodHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "GET":
+		if h.Get != nil {
+			h.Get.ServeHTTP(w, r)
+			return
 		}
-		sort.Strings(allow)
-		w.Header().Set("Allow", strings.Join(allow, ", "))
-		if req.Method == "OPTIONS" {
-			w.WriteHeader(http.StatusOK)
-		} else {
-			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	case "HEAD":
+		if h.Head != nil {
+			h.Head.ServeHTTP(w, r)
+			return
 		}
+		if h.Get != nil {
+			h.Get.ServeHTTP(w, r)
+			return
+		}
+	case "POST":
+		if h.Post != nil {
+			h.Post.ServeHTTP(w, r)
+			return
+		}
+	case "PUT":
+		if h.Put != nil {
+			h.Put.ServeHTTP(w, r)
+			return
+		}
+	case "PATCH":
+		if h.Patch != nil {
+			h.Patch.ServeHTTP(w, r)
+			return
+		}
+	case "DELETE":
+		if h.Delete != nil {
+			h.Delete.ServeHTTP(w, r)
+			return
+		}
+	case "OPTIONS":
+		if h.Options != nil {
+			h.Options.ServeHTTP(w, r)
+			return
+		}
+		h.setAllowHeader(w.Header())
+		w.WriteHeader(http.StatusOK)
+		return
 	}
+	h.setAllowHeader(w.Header())
+	http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+}
+
+func (h MethodHandler) setAllowHeader(header http.Header) {
+	allow := make([]string, 0, 6)
+	if h.Delete != nil {
+		allow = append(allow, "DELETE")
+	}
+	if h.Get != nil {
+		allow = append(allow, "GET")
+	}
+	if h.Head != nil {
+		allow = append(allow, "HEAD")
+	}
+	if h.Patch != nil {
+		allow = append(allow, "PATCH")
+	}
+	if h.Post != nil {
+		allow = append(allow, "POST")
+	}
+	if h.Put != nil {
+		allow = append(allow, "PUT")
+	}
+	header.Set("Allow", strings.Join(allow, ", "))
+
 }
 
 // loggingHandler is the http.Handler implementation for LoggingHandlerTo and its friends

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -15,10 +15,9 @@ import (
 	"time"
 )
 
-const (
-	ok         = "ok\n"
-	notAllowed = "Method not allowed\n"
-)
+const ok = "ok\n"
+
+var notAllowed = http.StatusText(http.StatusMethodNotAllowed) + "\n"
 
 var okHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 	w.Write([]byte(ok))
@@ -45,17 +44,17 @@ func TestMethodHandler(t *testing.T) {
 		{newRequest("OPTIONS", "/foo"), MethodHandler{}, http.StatusOK, "", ""},
 
 		// A single handler
-		{newRequest("GET", "/foo"), MethodHandler{"GET": okHandler}, http.StatusOK, "", ok},
-		{newRequest("POST", "/foo"), MethodHandler{"GET": okHandler}, http.StatusMethodNotAllowed, "GET", notAllowed},
+		{newRequest("GET", "/foo"), MethodHandler{Get: okHandler}, http.StatusOK, "", ok},
+		{newRequest("POST", "/foo"), MethodHandler{Get: okHandler}, http.StatusMethodNotAllowed, "GET", notAllowed},
 
 		// Multiple handlers
-		{newRequest("GET", "/foo"), MethodHandler{"GET": okHandler, "POST": okHandler}, http.StatusOK, "", ok},
-		{newRequest("POST", "/foo"), MethodHandler{"GET": okHandler, "POST": okHandler}, http.StatusOK, "", ok},
-		{newRequest("DELETE", "/foo"), MethodHandler{"GET": okHandler, "POST": okHandler}, http.StatusMethodNotAllowed, "GET, POST", notAllowed},
-		{newRequest("OPTIONS", "/foo"), MethodHandler{"GET": okHandler, "POST": okHandler}, http.StatusOK, "GET, POST", ""},
+		{newRequest("GET", "/foo"), MethodHandler{Get: okHandler, Post: okHandler}, http.StatusOK, "", ok},
+		{newRequest("POST", "/foo"), MethodHandler{Get: okHandler, Post: okHandler}, http.StatusOK, "", ok},
+		{newRequest("DELETE", "/foo"), MethodHandler{Get: okHandler, Post: okHandler}, http.StatusMethodNotAllowed, "GET, POST", notAllowed},
+		{newRequest("OPTIONS", "/foo"), MethodHandler{Get: okHandler, Post: okHandler}, http.StatusOK, "GET, POST", ""},
 
 		// Override OPTIONS
-		{newRequest("OPTIONS", "/foo"), MethodHandler{"OPTIONS": okHandler}, http.StatusOK, "", ok},
+		{newRequest("OPTIONS", "/foo"), MethodHandler{Options: okHandler}, http.StatusOK, "", ok},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
The patch does two main things:
* it uses a struct instead of a map. This is to be safer and detect typos. It also seems more appropriate than a map since the list of http methods is known.
* Using GET as a fallback if HEAD isn't defined. This is often a default and taken care of in the caller's handlers (`http.ServeContent` handles it).

And a minor fix in documentation: status is 405, not 406.

I am not sure if this is worth breaking the existing API, but I'll submit it anyway.
Also, I'm wondering if it would be better to use field names like `GET` instead of `Get`, even if this is quite unnatural in Go.