### PR TITLE
Implement Hijacker too for Websocket to work

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -43,11 +43,17 @@ func CompressHandler(h http.Handler) http.Handler {
 				gw := gzip.NewWriter(w)
 				defer gw.Close()
 
+				h, hok := w.(http.Hijacker)
+				if !hok { /* w is not Hijacker... oh well... */
+					h = nil
+				}
+
 				w = &compressResponseWriter{
 					Writer:         gw,
 					ResponseWriter: w,
-					Hijacker:       w.(http.Hijacker),
+					Hijacker:       h,
 				}
+
 				break L
 			case "deflate":
 				w.Header().Set("Content-Encoding", "deflate")
@@ -56,11 +62,17 @@ func CompressHandler(h http.Handler) http.Handler {
 				fw, _ := flate.NewWriter(w, flate.DefaultCompression)
 				defer fw.Close()
 
+				h, hok := w.(http.Hijacker)
+				if !hok { /* w is not Hijacker... oh well... */
+					h = nil
+				}
+
 				w = &compressResponseWriter{
 					Writer:         fw,
 					ResponseWriter: w,
-					Hijacker:       w.(http.Hijacker),
+					Hijacker:       h,
 				}
+
 				break L
 			}
 		}

--- a/compress.go
+++ b/compress.go
@@ -15,6 +15,7 @@ import (
 type compressResponseWriter struct {
 	io.Writer
 	http.ResponseWriter
+	http.Hijacker
 }
 
 func (w *compressResponseWriter) Header() http.Header {
@@ -45,6 +46,7 @@ func CompressHandler(h http.Handler) http.Handler {
 				w = &compressResponseWriter{
 					Writer:         gw,
 					ResponseWriter: w,
+					Hijacker:       w.(http.Hijacker),
 				}
 				break L
 			case "deflate":
@@ -57,6 +59,7 @@ func CompressHandler(h http.Handler) http.Handler {
 				w = &compressResponseWriter{
 					Writer:         fw,
 					ResponseWriter: w,
+					Hijacker:       w.(http.Hijacker),
 				}
 				break L
 			}


### PR DESCRIPTION
When using `CompressHandler`, [github.com/gorilla/websocket](https://github.com/gorilla/websocket) does not work, because `compressResponseWriter` don't implement `Hijacker` interface used in `websocket` package.

This pull request fixes it.