### PR TITLE
New Function: ProxyHeaders Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 gorilla/handlers
 ================
-[[![GoDoc](https://godoc.org/github.com/gorilla/handlers?status.svg)](https://godoc.org/github.com/gorilla/handlers)![Build Status](https://travis-ci.org/gorilla/handlers.svg?branch=master)](https://travis-ci.org/gorilla/handlers)
+[[![GoDoc](https://godoc.org/github.com/gorilla/handlers?status.svg)](https://godoc.org/github.com/gorilla/handlers) ![Build Status](https://travis-ci.org/gorilla/handlers.svg?branch=master)](https://travis-ci.org/gorilla/handlers)
 
 Package handlers is a collection of handlers (aka "HTTP middleware") for use
 with Go's `net/http` package (or any framework supporting `http.Handler`), including:
@@ -13,12 +13,14 @@ with Go's `net/http` package (or any framework supporting `http.Handler`), inclu
 * `CompressHandler` for gzipping responses.
 * `ContentTypeHandler` for validating requests against a list of accepted
   content types.
+* `MethodHandler` for matching HTTP methods against handlers in a
+  `map[string]http.Handler`
+* `ProxyHeaders` for populating `r.RemoteAddr` and `r.URL.Scheme` based on the
+  `X-Forwarded-For`, `X-Real-IP`, `X-Forwarded-Proto` and RFC7239 `Forwarded`
+  headers when running a Go server behind a HTTP reverse proxy.
 
 Other handlers are documented [on the Gorilla
 website](http://www.gorillatoolkit.org/pkg/handlers).
-
-*Warning:* This package is a work in progress and the APIs are subject to change.
-Consider this a v0 project.
 
 ## Example
 

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,9 @@
+/*
+Package handlers is a collection of handlers (aka "HTTP middleware") for use
+with Go's net/http package (or any framework supporting http.Handler).
+
+The package includes handlers for logging in standardised formats, compressing
+HTTP responses, validating content types and other useful tools for manipulating
+requests and responses.
+*/
+package handlers

--- a/handlers.go
+++ b/handlers.go
@@ -1,6 +1,7 @@
 // Copyright 2013 The Gorilla Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
 package handlers
 
 import (

--- a/handlers.go
+++ b/handlers.go
@@ -1,10 +1,6 @@
 // Copyright 2013 The Gorilla Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
-
-/*
-Package handlers is a collection of handlers for use with Go's net/http package.
-*/
 package handlers
 
 import (

--- a/proxy_headers.go
+++ b/proxy_headers.go
@@ -1,0 +1,113 @@
+package handlers
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+var (
+	// De-facto standard header keys.
+	xForwardedFor   = http.CanonicalHeaderKey("X-Forwarded-For")
+	xRealIP         = http.CanonicalHeaderKey("X-Real-IP")
+	xForwardedProto = http.CanonicalHeaderKey("X-Forwarded-Scheme")
+)
+
+var (
+	// RFC7239 defines a new "Forwarded: " header designed to replace the
+	// existing use of X-Forwarded-* headers.
+	// e.g. Forwarded: for=192.0.2.60;proto=https;by=203.0.113.43
+	forwarded = http.CanonicalHeaderKey("Forwarded")
+	// Allows for a sub-match of the first value after 'for=' to the next
+	// comma, semi-colon or space. The match is case-insensitive.
+	forRegex = regexp.MustCompile(`(?i)(?:for=)([^(;|,| )]+)`)
+	// Allows for a sub-match for the first instance of scheme (http|https)
+	// prefixed by 'proto='. The match is case-insensitive.
+	protoRegex = regexp.MustCompile(`(?i)(?:proto=)(https|http)`)
+)
+
+// ProxyHeaders inspects common reverse proxy headers and sets the corresponding
+// fields in the HTTP request struct. These are X-Forwarded-For and X-Real-IP
+// for the remote (client) IP address, X-Forwarded-Proto for the scheme
+// (http|https) and the RFC7239 Forwarded header, which may include both client
+// IPs and schemes.
+//
+// NOTE: This middleware should only be used when behind a reverse
+// proxy like nginx, HAProxy or Apache. Reverse proxies that don't (or are
+// configured not to) strip these headers from client requests, or where these
+// headers are accepted "as is" from a remote client (e.g. when Go is not behind
+// a proxy), can manifest as a vulnerability if your application uses these
+// headers for validating the 'trustworthiness' of a request.
+func ProxyHeaders(h http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		// Set the remote IP with the value passed from the proxy.
+		if fwd := getIP(r); fwd != "" {
+			r.RemoteAddr = fwd
+		}
+
+		// Set the scheme (proto) with the value passed from the proxy.
+		if scheme := getScheme(r); scheme != "" {
+			r.URL.Scheme = scheme
+		}
+
+		// Call the next handler in the chain.
+		h.ServeHTTP(w, r)
+	}
+
+	return http.HandlerFunc(fn)
+}
+
+// getIP retrieves the IP from the X-Forwarded-For, X-Real-IP and RFC7239
+// Forwarded headers (in that order).
+func getIP(r *http.Request) string {
+	var addr string
+
+	if fwd := r.Header.Get(xForwardedFor); fwd != "" {
+		// Only grab the first (client) address. Note that '192.168.0.1,
+		// 10.1.1.1' is a valid key for X-Forwarded-For where addresses after
+		// the first may represent forwarding proxies earlier in the chain.
+		s := strings.Index(fwd, ", ")
+		if s == -1 {
+			s = len(fwd)
+		}
+		addr = fwd[:s]
+	} else if fwd := r.Header.Get(xRealIP); fwd != "" {
+		// X-Real-IP should only contain one IP address (the client making the
+		// request).
+		addr = fwd
+	} else if fwd := r.Header.Get(forwarded); fwd != "" {
+		// match should contain at least two elements if the protocol was
+		// specified in the Forwarded header. The first element will always be
+		// the 'for=' capture, which we ignore. In the case of multiple IP
+		// addresses (for=8.8.8.8, 8.8.4.4,172.16.1.20 is valid) we only
+		// extract the first, which should be the client IP.
+		if match := forRegex.FindStringSubmatch(fwd); len(match) > 1 {
+			// IPv6 addresses in Forwarded headers are quoted-strings. We strip
+			// these quotes.
+			addr = strings.Trim(match[1], `"`)
+		}
+	}
+
+	return addr
+}
+
+// getScheme retrieves the scheme from the X-Forwarded-Proto and RFC7239
+// Forwarded headers (in that order).
+func getScheme(r *http.Request) string {
+	var scheme string
+
+	// Retrieve the scheme from X-Forwarded-Proto.
+	if proto := r.Header.Get(xForwardedProto); proto != "" {
+		scheme = strings.ToLower(proto)
+	} else if proto := r.Header.Get(forwarded); proto != "" {
+		// match should contain at least two elements if the protocol was
+		// specified in the Forwarded header. The first element will always be
+		// the 'proto=' capture, which we ignore. In the case of multiple proto
+		// parameters (invalid) we only extract the first.
+		if match := protoRegex.FindStringSubmatch(proto); len(match) > 1 {
+			scheme = strings.ToLower(match[1])
+		}
+	}
+
+	return scheme
+}

--- a/proxy_headers_test.go
+++ b/proxy_headers_test.go
@@ -1,0 +1,100 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type headerTable struct {
+	key      string // header key
+	val      string // header val
+	expected string // expected result
+}
+
+func TestGetIP(t *testing.T) {
+	headers := []headerTable{
+		{xForwardedFor, "8.8.8.8", "8.8.8.8"},                                         // Single address
+		{xForwardedFor, "8.8.8.8, 8.8.4.4", "8.8.8.8"},                                // Multiple
+		{xForwardedFor, "[2001:db8:cafe::17]:4711", "[2001:db8:cafe::17]:4711"},       // IPv6 address
+		{xForwardedFor, "", ""},                                                       // None
+		{xRealIP, "8.8.8.8", "8.8.8.8"},                                               // Single address
+		{xRealIP, "8.8.8.8, 8.8.4.4", "8.8.8.8, 8.8.4.4"},                             // Multiple
+		{xRealIP, "[2001:db8:cafe::17]:4711", "[2001:db8:cafe::17]:4711"},             // IPv6 address
+		{xRealIP, "", ""},                                                             // None
+		{forwarded, `for="_gazonk"`, "_gazonk"},                                       // Hostname
+		{forwarded, `For="[2001:db8:cafe::17]:4711`, `[2001:db8:cafe::17]:4711`},      // IPv6 address
+		{forwarded, `for=192.0.2.60;proto=http;by=203.0.113.43`, `192.0.2.60`},        // Multiple params
+		{forwarded, `for=192.0.2.43, for=198.51.100.17`, "192.0.2.43"},                // Multiple params
+		{forwarded, `for="workstation.local",for=198.51.100.17`, "workstation.local"}, // Hostname
+	}
+
+	for _, v := range headers {
+		req := &http.Request{
+			Header: http.Header{
+				v.key: []string{v.val},
+			}}
+		res := getIP(req)
+		if res != v.expected {
+			t.Fatalf("wrong header for %s: got %s want %s", v.key, res,
+				v.expected)
+		}
+	}
+}
+
+func TestGetScheme(t *testing.T) {
+	headers := []headerTable{
+		{xForwardedProto, "https", "https"},
+		{xForwardedProto, "http", "http"},
+		{xForwardedProto, "HTTP", "http"},
+		{forwarded, `For="[2001:db8:cafe::17]:4711`, ""},                      // No proto
+		{forwarded, `for=192.0.2.43, for=198.51.100.17;proto=https`, "https"}, // Multiple params before proto
+		{forwarded, `for=172.32.10.15; proto=https;by=127.0.0.1`, "https"},    // Space before proto
+		{forwarded, `for=192.0.2.60;proto=http;by=203.0.113.43`, "http"},      // Multiple params
+	}
+
+	for _, v := range headers {
+		req := &http.Request{
+			Header: http.Header{
+				v.key: []string{v.val},
+			},
+		}
+		res := getScheme(req)
+		if res != v.expected {
+			t.Fatalf("wrong header for %s: got %s want %s", v.key, res,
+				v.expected)
+		}
+	}
+}
+
+// Test the middleware end-to-end
+func TestProxyHeaders(t *testing.T) {
+	rr := httptest.NewRecorder()
+	r := newRequest("GET", "/")
+
+	r.Header.Set(xForwardedFor, "8.8.8.8")
+	r.Header.Set(xForwardedProto, "https")
+
+	var addr string
+	var proto string
+	ProxyHeaders(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			addr = r.RemoteAddr
+			proto = r.URL.Scheme
+		})).ServeHTTP(rr, r)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bad status: got %d want %d", rr.Code, http.StatusOK)
+	}
+
+	if addr != r.Header.Get(xForwardedFor) {
+		t.Fatalf("wrong address: got %s want %s", addr,
+			r.Header.Get(xForwardedFor))
+	}
+
+	if proto != r.Header.Get(xForwardedProto) {
+		t.Fatalf("wrong address: got %s want %s", proto,
+			r.Header.Get(xForwardedProto))
+	}
+
+}


### PR DESCRIPTION
From the commit message:

* Extracts the client IP from X-Forwarded-For and X-Real-IP
* Extracts the scheme from X-Forwarded-Scheme
* Extracts the IP and/or scheme from RFC7239 Forwarded headers.

The tests *should* be fairly solid (100% coverage, although we know coverage isn't a great metric). Most of this implementation is pretty standard, but for posterity:

The `X-Forwarded-For`, `X-Real-IP` and `X-Forwarded-Proto` are de-facto standards adopted by [nginx](http://nginx.org/en/docs/http/ngx_http_realip_module.html), [Apache](http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#x-headers), [HAProxy](http://httpd.apache.org/docs/2.2/mod/mod_proxy.html#x-headers), etc. 

The RFC7239 docs are here: http://tools.ietf.org/html/rfc7239#section-4 — and I suggest averting your eyes when it comes to what is considered an "acceptable" header (spaces, no spaces, etc.). An example of this header would be `Forwarded: for=192.0.2.60;proto=http;by=203.0.113.43`.

I also moved the godoc into `doc.go` and added the missing middleware functions to the README.