### PR TITLE
Fixed README build badge link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 gorilla/handlers
 ================
-[[![GoDoc](https://godoc.org/github.com/gorilla/handlers?status.svg)](https://godoc.org/github.com/gorilla/handlers) ![Build Status](https://travis-ci.org/gorilla/handlers.svg?branch=master)](https://travis-ci.org/gorilla/handlers)
+[![GoDoc](https://godoc.org/github.com/gorilla/handlers?status.svg)](https://godoc.org/github.com/gorilla/handlers) [![Build Status](https://travis-ci.org/gorilla/handlers.svg?branch=master)](https://travis-ci.org/gorilla/handlers)
 
 Package handlers is a collection of handlers (aka "HTTP middleware") for use
 with Go's `net/http` package (or any framework supporting `http.Handler`), including:


### PR DESCRIPTION
Just noticed it—typo in the Markdown on my part broke the link (not the image) @kisielk 