### PR TITLE
feature: CanonicalHost middleware/handler.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ with Go's `net/http` package (or any framework supporting `http.Handler`), inclu
 * `ProxyHeaders` for populating `r.RemoteAddr` and `r.URL.Scheme` based on the
   `X-Forwarded-For`, `X-Real-IP`, `X-Forwarded-Proto` and RFC7239 `Forwarded`
   headers when running a Go server behind a HTTP reverse proxy.
+* `CanonicalHost` for re-directing to the preferred host when handling multiple 
+  domains (i.e. multiple CNAME aliases).
 
 Other handlers are documented [on the Gorilla
 website](http://www.gorillatoolkit.org/pkg/handlers).

--- a/canonical.go
+++ b/canonical.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type canonical struct {
+	h      http.Handler
+	domain string
+	code   int
+}
+
+// CanonicalHost is HTTP middleware that re-directs requests to the canonical
+// domain. It accepts a domain and a status code (e.g. 301 or 302) and
+// re-directs clients to this domain. The existing request path is maintained.
+//
+// Note: If the provided domain is considered invalid by url.Parse or otherwise
+// returns an empty scheme or host, clients are not re-directed.
+// not re-directed.
+//
+// Example:
+//
+//  r := mux.NewRouter()
+//  canonical := handlers.CanonicalHost("http://www.gorillatoolkit.org", 302)
+//  r.HandleFunc("/route", YourHandler)
+//
+//  log.Fatal(http.ListenAndServe(":7000", canonical(r)))
+//
+func CanonicalHost(domain string, code int) func(h http.Handler) http.Handler {
+	fn := func(h http.Handler) http.Handler {
+		return canonical{h, domain, code}
+	}
+
+	return fn
+}
+
+func (c canonical) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	dest, err := url.Parse(c.domain)
+	if err != nil {
+		// Call the next handler if the provided domain fails to parse.
+		c.h.ServeHTTP(w, r)
+		return
+	}
+
+	if dest.Scheme == "" || dest.Host == "" {
+		// Call the next handler if the scheme or host are empty.
+		// Note that url.Parse won't fail on in this case.
+		c.h.ServeHTTP(w, r)
+		return
+	}
+
+	if !strings.EqualFold(cleanHost(r.Host), dest.Host) {
+		// Re-build the destination URL
+		dest := dest.Scheme + "://" + dest.Host + r.URL.Path
+		http.Redirect(w, r, dest, c.code)
+	}
+
+	c.h.ServeHTTP(w, r)
+}
+
+// cleanHost cleans invalid Host headers by stripping anything after '/' or ' '.
+// This is backported from Go 1.5 (in response to issue #11206) and attempts to
+// mitigate malformed Host headers that do not match the format in RFC7230.
+func cleanHost(in string) string {
+	if i := strings.IndexAny(in, " /"); i != -1 {
+		return in[:i]
+	}
+	return in
+}

--- a/canonical_test.go
+++ b/canonical_test.go
@@ -1,0 +1,73 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCleanHost(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"www.google.com", "www.google.com"},
+		{"www.google.com foo", "www.google.com"},
+		{"www.google.com/foo", "www.google.com"},
+		{" first character is a space", ""},
+	}
+	for _, tt := range tests {
+		got := cleanHost(tt.in)
+		if tt.want != got {
+			t.Errorf("cleanHost(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestCanonicalHost(t *testing.T) {
+	gorilla := "http://www.gorillatoolkit.org"
+
+	rr := httptest.NewRecorder()
+	r := newRequest("GET", "http://www.example.com/")
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	// Test a re-direct: should return a 302 Found.
+	CanonicalHost(gorilla, http.StatusFound)(testHandler).ServeHTTP(rr, r)
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("bad status: got %v want %v", rr.Code, http.StatusFound)
+	}
+
+	if rr.Header().Get("Location") != gorilla+r.URL.Path {
+		t.Fatalf("bad re-direct: got %q want %q", rr.Header().Get("Location"), gorilla+r.URL.Path)
+	}
+
+}
+
+func TestBadDomain(t *testing.T) {
+	rr := httptest.NewRecorder()
+	r := newRequest("GET", "http://www.example.com/")
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	// Test a bad domain - should return 200 OK.
+	CanonicalHost("%", http.StatusFound)(testHandler).ServeHTTP(rr, r)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bad status: got %v want %v", rr.Code, http.StatusOK)
+	}
+}
+
+func TestEmptyHost(t *testing.T) {
+	rr := httptest.NewRecorder()
+	r := newRequest("GET", "http://www.example.com/")
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	// Test a domain that returns an empty url.Host from url.Parse.
+	CanonicalHost("hello.com", http.StatusFound)(testHandler).ServeHTTP(rr, r)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("bad status: got %v want %v", rr.Code, http.StatusOK)
+	}
+}


### PR DESCRIPTION
New `CanonicalHost` middleware:

- Re-directs to the "canonical" host. Useful when handling multiple domains and
  you wish to re-direct to the canonical domain for user experience or SEO.
- Includes tests for the middleware and invalid domains.

Example:

```go
func main() {
	r := mux.NewRouter()
	canonical := handlers.CanonicalHost("http://www.gorillatoolkit.org", 302)

	r.HandleFunc("/route", YourHandler)
	log.Fatal(http.ListenAndServe(":7000", canonical(r)))
}
```