### PR TITLE
fix "http: multiple response.WriteHeader calls" in CanonicalHost

### DIFF
--- a/canonical.go
+++ b/canonical.go
@@ -55,6 +55,7 @@ func (c canonical) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Re-build the destination URL
 		dest := dest.Scheme + "://" + dest.Host + r.URL.Path
 		http.Redirect(w, r, dest, c.code)
+		return
 	}
 
 	c.h.ServeHTTP(w, r)


### PR DESCRIPTION
After calling http.Redirect() we should finish the request in order to avoid executing underlying layers.