### PR TITLE
Added fix and test to address #41 (lack of return after redir.)

### DIFF
--- a/canonical.go
+++ b/canonical.go
@@ -18,7 +18,6 @@ type canonical struct {
 //
 // Note: If the provided domain is considered invalid by url.Parse or otherwise
 // returns an empty scheme or host, clients are not re-directed.
-// not re-directed.
 //
 // Example:
 //
@@ -55,6 +54,7 @@ func (c canonical) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// Re-build the destination URL
 		dest := dest.Scheme + "://" + dest.Host + r.URL.Path
 		http.Redirect(w, r, dest, c.code)
+		return
 	}
 
 	c.h.ServeHTTP(w, r)

--- a/canonical_test.go
+++ b/canonical_test.go
@@ -1,8 +1,12 @@
 package handlers
 
 import (
+	"bufio"
+	"bytes"
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -69,5 +73,38 @@ func TestEmptyHost(t *testing.T) {
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("bad status: got %v want %v", rr.Code, http.StatusOK)
+	}
+}
+
+func TestHeaderWrites(t *testing.T) {
+	gorilla := "http://www.gorillatoolkit.org"
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	})
+
+	// Catch the log output to ensure we don't write multiple headers.
+	var b bytes.Buffer
+	buf := bufio.NewWriter(&b)
+	tl := log.New(buf, "test: ", log.Lshortfile)
+
+	srv := httptest.NewServer(
+		CanonicalHost(gorilla, http.StatusFound)(testHandler))
+	defer srv.Close()
+	srv.Config.ErrorLog = tl
+
+	_, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = buf.Flush()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We rely on the error not changing: net/http does not export it.
+	if strings.Contains(b.String(), "multiple response.WriteHeader calls") {
+		t.Fatalf("re-direct did not return early: multiple header writes")
 	}
 }


### PR DESCRIPTION
* Addressed the lack of a naked `return` statement after a `http.Redirect` in CanonicalHost that resulted in multiple header writes.
* Added a test to string-match the error log returned from http.Server when this occurs to avoid future regression.

Note that (in order to keep this self-contained) I replicated the fix by @Kernel1 in #41.