### PR TITLE
compress: incorrect content-length header

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -18,6 +18,11 @@ type compressResponseWriter struct {
 	http.Hijacker
 }
 
+func (w *compressResponseWriter) WriteHeader(c int) {
+	w.ResponseWriter.Header().Del("Content-Length")
+	w.ResponseWriter.WriteHeader(c)
+}
+
 func (w *compressResponseWriter) Header() http.Header {
 	return w.ResponseWriter.Header()
 }
@@ -27,6 +32,7 @@ func (w *compressResponseWriter) Write(b []byte) (int, error) {
 	if h.Get("Content-Type") == "" {
 		h.Set("Content-Type", http.DetectContentType(b))
 	}
+	h.Del("Content-Length")
 
 	return w.Writer.Write(b)
 }

--- a/compress_test.go
+++ b/compress_test.go
@@ -8,11 +8,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 )
 
 func compressedRequest(w *httptest.ResponseRecorder, compression string) {
 	CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", strconv.Itoa(9*1024))
 		for i := 0; i < 1024; i++ {
 			io.WriteString(w, "Gorilla!\n")
 		}
@@ -25,17 +27,37 @@ func compressedRequest(w *httptest.ResponseRecorder, compression string) {
 
 }
 
+func TestCompressHandlerNoCompression(t *testing.T) {
+	w := httptest.NewRecorder()
+	compressedRequest(w, "")
+	if enc := w.HeaderMap.Get("Content-Encoding"); enc != "" {
+		t.Errorf("wrong content encoding, got %q want %q", enc, "")
+	}
+	if ct := w.HeaderMap.Get("Content-Type"); ct != "" {
+		t.Errorf("wrong content type, got %q want %q", ct, "")
+	}
+	if w.Body.Len() != 1024*9 {
+		t.Errorf("wrong len, got %d want %d", w.Body.Len(), 1024*9)
+	}
+	if l := w.HeaderMap.Get("Content-Length"); l != "9216" {
+		t.Errorf("wrong content-length. got %q expected %d", l, 1024*9)
+	}
+}
+
 func TestCompressHandlerGzip(t *testing.T) {
 	w := httptest.NewRecorder()
 	compressedRequest(w, "gzip")
 	if w.HeaderMap.Get("Content-Encoding") != "gzip" {
-		t.Fatalf("wrong content encoding, got %d want %d", w.HeaderMap.Get("Content-Encoding"), "gzip")
+		t.Errorf("wrong content encoding, got %q want %q", w.HeaderMap.Get("Content-Encoding"), "gzip")
 	}
 	if w.HeaderMap.Get("Content-Type") != "text/plain; charset=utf-8" {
-		t.Fatalf("wrong content type, got %s want %s", w.HeaderMap.Get("Content-Type"), "text/plain; charset=utf-8")
+		t.Errorf("wrong content type, got %s want %s", w.HeaderMap.Get("Content-Type"), "text/plain; charset=utf-8")
 	}
 	if w.Body.Len() != 72 {
-		t.Fatalf("wrong len, got %d want %d", w.Body.Len(), 72)
+		t.Errorf("wrong len, got %d want %d", w.Body.Len(), 72)
+	}
+	if l := w.HeaderMap.Get("Content-Length"); l != "" {
+		t.Errorf("wrong content-length. got %q expected %q", l, "")
 	}
 }
 
@@ -43,7 +65,7 @@ func TestCompressHandlerDeflate(t *testing.T) {
 	w := httptest.NewRecorder()
 	compressedRequest(w, "deflate")
 	if w.HeaderMap.Get("Content-Encoding") != "deflate" {
-		t.Fatalf("wrong content encoding, got %d want %d", w.HeaderMap.Get("Content-Encoding"), "deflate")
+		t.Fatalf("wrong content encoding, got %q want %q", w.HeaderMap.Get("Content-Encoding"), "deflate")
 	}
 	if w.HeaderMap.Get("Content-Type") != "text/plain; charset=utf-8" {
 		t.Fatalf("wrong content type, got %s want %s", w.HeaderMap.Get("Content-Type"), "text/plain; charset=utf-8")
@@ -57,7 +79,7 @@ func TestCompressHandlerGzipDeflate(t *testing.T) {
 	w := httptest.NewRecorder()
 	compressedRequest(w, "gzip, deflate ")
 	if w.HeaderMap.Get("Content-Encoding") != "gzip" {
-		t.Fatalf("wrong content encoding, got %s want %s", w.HeaderMap.Get("Content-Encoding"), "gzip")
+		t.Fatalf("wrong content encoding, got %q want %q", w.HeaderMap.Get("Content-Encoding"), "gzip")
 	}
 	if w.HeaderMap.Get("Content-Type") != "text/plain; charset=utf-8" {
 		t.Fatalf("wrong content type, got %s want %s", w.HeaderMap.Get("Content-Type"), "text/plain; charset=utf-8")


### PR DESCRIPTION
If a handler manually sets a content-length header when using `CompressHandler` the response is invalid because of a content-length mismatch. To be correct in all cases the `Content-Length` header (if there is one) should be cleared.