### PR TITLE
correct the requestURI for LoggingHandler when the server run as proxy server

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -251,6 +251,10 @@ func buildCommonLogLine(req *http.Request, url url.URL, ts time.Time, status int
 	}
 
 	uri := req.RequestURI
+
+	// Requests using the CONNECT method over HTTP/2.0 must use
+	// the authority field (aka r.Host) to identify the target.
+	// Refer: https://httpwg.github.io/specs/rfc7540.html#CONNECT
 	if req.ProtoMajor == 2 && req.Method == "CONNECT" {
 		uri = req.Host
 	}

--- a/handlers.go
+++ b/handlers.go
@@ -251,11 +251,11 @@ func buildCommonLogLine(req *http.Request, url url.URL, ts time.Time, status int
 	}
 
 	uri := req.RequestURI
-	if uri == "" {
-		uri = url.RequestURI()
-	}
 	if req.ProtoMajor == 2 && req.Method == "CONNECT" {
 		uri = req.Host
+	}
+	if uri == "" {
+		uri = url.RequestURI()
 	}
 
 	buf := make([]byte, 0, 3*(len(host)+len(username)+len(req.Method)+len(uri)+len(req.Proto)+50)/2)

--- a/handlers.go
+++ b/handlers.go
@@ -250,7 +250,10 @@ func buildCommonLogLine(req *http.Request, url url.URL, ts time.Time, status int
 		host = req.RemoteAddr
 	}
 
-	uri := url.RequestURI()
+	uri := req.RequestURI
+	if req.ProtoMajor == 2 && req.Method == "CONNECT" {
+		uri = req.Host
+	}
 
 	buf := make([]byte, 0, 3*(len(host)+len(username)+len(req.Method)+len(uri)+len(req.Proto)+50)/2)
 	buf = append(buf, host...)

--- a/handlers.go
+++ b/handlers.go
@@ -251,6 +251,9 @@ func buildCommonLogLine(req *http.Request, url url.URL, ts time.Time, status int
 	}
 
 	uri := req.RequestURI
+	if uri == "" {
+		uri = url.RequestURI()
+	}
 	if req.ProtoMajor == 2 && req.Method == "CONNECT" {
 		uri = req.Host
 	}


### PR DESCRIPTION
I use the LoggingHandler to log the request, my server run as a proxy server,
the request "GET http://xxxx/yyyy" will log as "GET /yyyy",
the request "CONNECT xxxx.com:443" will log as "CONNECT /",

This change corrects the requestURI when the server run as a proxy server.