### PR TITLE
[feature] Pooled gzip writer

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -8,14 +8,59 @@ import (
 	"compress/flate"
 	"compress/gzip"
 	"io"
+	"log"
+	"mime"
 	"net/http"
 	"strings"
 	"sync"
 )
 
+// compressableTypes are the HTTP Content-Types that will be compressed by
+// compressHandler in a response.
+var compressableTypes = []string{
+	"text/html",
+	"text/richtext",
+	"text/plain",
+	"text/css",
+	"text/x-script",
+	"text/x-component",
+	"text/x-java-source",
+	"application/javascript",
+	"application/x-javascript",
+	"text/javascript",
+	"text/js",
+	"image/x-icon",
+	"application/x-perl",
+	"application/x-httpd-cgi",
+	"text/xml",
+	"application/xml",
+	"application/xml+rss",
+	"application/json",
+	"multipart/bag",
+	"multipart/mixed",
+	"application/xhtml+xml",
+	"font/ttf",
+	"font/otf",
+	"font/x-woff",
+	"image/svg+xml",
+	"application/vnd.ms-fontobject",
+	"application/ttf",
+	"application/x-ttf",
+	"application/otf",
+	"application/x-otf",
+	"application/truetype",
+	"application/opentype",
+	"application/x-opentype",
+	"application/woff",
+	"application/eot",
+	"application/font",
+	"application/font-woff",
+	"application/font-sfnt",
+}
+
 // gzipPool is a pool of gzip writers using gzip.DefaultCompression.
-// Note: Due to the inability to change the level after initialization other
-// levels do not use pooled writers.
+// Note: Due to the inability to change the level after initialization, levels
+// other than flate.DefaultCompression do not use pooled writers.
 var gzipPool = sync.Pool{
 	New: func() interface{} {
 		return gzip.NewWriter(nil)
@@ -45,8 +90,16 @@ func (w *compressResponseWriter) Header() http.Header {
 
 func (w *compressResponseWriter) Write(b []byte) (int, error) {
 	h := w.ResponseWriter.Header()
-	if h.Get("Content-Type") == "" {
+	ctype := h.Get("Content-Type")
+	if ctype == "" {
 		h.Set("Content-Type", http.DetectContentType(b))
+	}
+
+	// If the MIME type of the response is not compressable, use the underlying
+	// (unmodified) writer instead.
+	if !mimeExists(ctype, compressableTypes) {
+		h.Del("Content-Encoding")
+		return w.ResponseWriter.Write(b)
 	}
 
 	h.Del("Content-Length")
@@ -57,6 +110,7 @@ func (w *compressResponseWriter) Write(b []byte) (int, error) {
 
 // CompressHandler gzip compresses HTTP responses for clients that support it
 // via the 'Accept-Encoding' header.
+//
 func CompressHandler(h http.Handler) http.Handler {
 	return &compressHandler{h, gzip.DefaultCompression}
 }
@@ -67,6 +121,11 @@ func CompressHandler(h http.Handler) http.Handler {
 // The compression level should be gzip.DefaultCompression, gzip.NoCompression,
 // or any integer value between gzip.BestSpeed and gzip.BestCompression inclusive.
 // gzip.DefaultCompression is used in case of invalid compression level.
+//
+// Note that most users should use CompressHandler (which uses the default
+// level), or be conscious of the increased client-side CPU requirements that
+// higher compression levels have. The default compression level also uses a
+// writer pool for gzip responses to reduce allocations across requests.
 func CompressHandlerLevel(h http.Handler, level int) http.Handler {
 	if level < gzip.DefaultCompression || level > gzip.BestCompression {
 		level = gzip.DefaultCompression
@@ -133,4 +192,23 @@ L:
 
 	// Call the wrapped handler
 	ch.h.ServeHTTP(w, r)
+}
+
+// mimeExists checks whether the provided MIME type is in a list of MIME types.
+func mimeExists(m string, accepted []string) bool {
+	for _, ctype := range accepted {
+		mtype, _, err := mime.ParseMediaType(m)
+		if err != nil {
+			log.Println(err)
+			return false
+		}
+
+		// MIME type == compressable type
+		if mtype == ctype {
+			return true
+		}
+
+	}
+
+	return false
 }

--- a/compress.go
+++ b/compress.go
@@ -33,6 +33,7 @@ func (w *compressResponseWriter) Write(b []byte) (int, error) {
 		h.Set("Content-Type", http.DetectContentType(b))
 	}
 	h.Del("Content-Length")
+	w.Header().Add("Vary", "Accept-Encoding")
 
 	return w.Writer.Write(b)
 }
@@ -60,7 +61,6 @@ func CompressHandlerLevel(h http.Handler, level int) http.Handler {
 			switch strings.TrimSpace(enc) {
 			case "gzip":
 				w.Header().Set("Content-Encoding", "gzip")
-				w.Header().Add("Vary", "Accept-Encoding")
 
 				gw, _ := gzip.NewWriterLevel(w, level)
 				defer gw.Close()
@@ -79,7 +79,6 @@ func CompressHandlerLevel(h http.Handler, level int) http.Handler {
 				break L
 			case "deflate":
 				w.Header().Set("Content-Encoding", "deflate")
-				w.Header().Add("Vary", "Accept-Encoding")
 
 				fw, _ := flate.NewWriter(w, level)
 				defer fw.Close()

--- a/compress_test.go
+++ b/compress_test.go
@@ -53,6 +53,9 @@ func TestCompressHandlerGzip(t *testing.T) {
 	if w.HeaderMap.Get("Content-Encoding") != "gzip" {
 		t.Errorf("wrong content encoding, got %q want %q", w.HeaderMap.Get("Content-Encoding"), "gzip")
 	}
+	if vary := w.HeaderMap.Get("Vary"); vary != "Accept-Encoding" {
+		t.Errorf("wrong content type, got %s want %s", vary, "Accept-Encoding")
+	}
 	if w.HeaderMap.Get("Content-Type") != "text/plain; charset=utf-8" {
 		t.Errorf("wrong content type, got %s want %s", w.HeaderMap.Get("Content-Type"), "text/plain; charset=utf-8")
 	}
@@ -69,6 +72,9 @@ func TestCompressHandlerDeflate(t *testing.T) {
 	compressedRequest(w, "deflate")
 	if w.HeaderMap.Get("Content-Encoding") != "deflate" {
 		t.Fatalf("wrong content encoding, got %q want %q", w.HeaderMap.Get("Content-Encoding"), "deflate")
+	}
+	if vary := w.HeaderMap.Get("Vary"); vary != "Accept-Encoding" {
+		t.Errorf("wrong content type, got %s want %s", vary, "Accept-Encoding")
 	}
 	if w.HeaderMap.Get("Content-Type") != "text/plain; charset=utf-8" {
 		t.Fatalf("wrong content type, got %s want %s", w.HeaderMap.Get("Content-Type"), "text/plain; charset=utf-8")


### PR DESCRIPTION
Working on https://github.com/gorilla/handlers/issues/44
- [x] Create a `compressHandler` type with an explicit `ServeHTTP` method instead of using closures.
- [x] Use MIME type introspection against `Content-Type` to inform what should be compressed
- [x] Add a `sync.Pool` of gzip writers for the default compression level (only, for now)
- [x] Benchmark compression levels.
- [x] Update docs to reflect where a pool is used and what types are compressed.
- [ ] Skip initialization of the gzip/flate writers for non-compressed responses.
- [ ] Show before/after benchmarks when serving a range of content (i.e. compressible vs. non-compressible).

BUG:
- [ ] Fix how we set/delete the `Content-Encoding` header to either `gzip` or `deflate`. If we set it within the `Write` method on our custom ResponseWriter, it's too late (headers must be written before). However, it's only until then do we know what `Content-Type` has written. Need to re-assess how we do this.
