### PR TITLE
[feature] Cross-Origin Request Sharing (CORS) Handler

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -2,12 +2,11 @@ package handlers
 
 import "net/http"
 
-type CORSHandler struct {
-	h    http.Handler
-	opts corsOptions
-}
+// CORSOption represents a functional option for configuring the CORS middleware.
+type CORSOption func(*cors) error
 
-type corsOptions struct {
+type cors struct {
+	h              http.Handler
 	allowedHeaders []string
 	allowedMethods []string
 	allowedOrigins []string
@@ -15,6 +14,107 @@ type corsOptions struct {
 	ignoreOptions  bool
 }
 
-func (ch *CORSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (ch *cors) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
+	ch.h.ServeHTTP(w, r)
+}
+
+// CORS provides Cross-Origin Resource Sharing middleware.
+// Example:
+//
+//  import (
+//      "net/http"
+//
+//      "github.com/gorilla/handlers"
+//      "github.com/gorilla/mux"
+//  )
+//
+//  func main() {
+//      r := mux.NewRouter()
+//      r.HandleFunc("/users", UserEndpoint)
+//      r.HandleFunc("/projects", ProjectEndpoint)
+//
+//      // Apply the CORS middleware to our top-level router, with the defaults.
+//      http.ListenAndServe(":8000", handlers.CORS()(r))
+//  }
+//
+func CORS(opts ...CORSOption) func(http.Handler) http.Handler {
+	ch := parseCORSOptions(opts...)
+
+	// TODO(all): Set defaults
+	// Note: append(allowedHeaders, defaultHeaders...) - the default headers here
+	// should always be allowed:
+	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Simple_requests
+
+	return func(h http.Handler) http.Handler {
+		ch.h = h
+		return ch
+	}
+}
+
+func parseCORSOptions(opts ...CORSOption) *cors {
+	ch := &cors{}
+
+	for _, option := range opts {
+		option(ch)
+	}
+
+	return ch
+}
+
+//
+// Functional options for configuring CORS.
+//
+
+// AllowedHeaders adds the provided headers to the list of allowed headers in a
+// CORS request.
+// The headers Content-Type, Expires, Cache-Control, ... are always allowed.
+func AllowedHeaders(headers []string) CORSOption {
+	return func(ch *cors) error {
+		ch.allowedHeaders = headers
+		return nil
+	}
+}
+
+// AllowedMethods ...
+func AllowedMethods(methods []string) CORSOption {
+	return func(ch *cors) error {
+		ch.allowedMethods = methods
+		return nil
+	}
+}
+
+// AllowedOrigins sets the allowed origins for CORS requests, as used in the
+// 'Allow-Access-Control-Origin' HTTP header.
+// Note: Passing in a []string{"*"} will allow any domain.
+func AllowedOrigins(origins []string) CORSOption {
+	return func(ch *cors) error {
+		ch.allowedOrigins = origins
+		return nil
+	}
+}
+
+// MaxAge determines the maximum age (in seconds) between preflight requests. A
+// maximum of 10 minutes is allowed. An age above this value will default to 10
+// minutes.
+func MaxAge(age int) CORSOption {
+	return func(ch *cors) error {
+		// Maximum of 10 minutes.
+		if age > 600 {
+			age = 600
+		}
+
+		ch.maxAge = age
+		return nil
+	}
+}
+
+// IgnoreOptions causes the CORS middleware to ignore OPTIONS requests, instead
+// passing them through to the next handler. This is useful when your application
+// or framework has a pre-existing mechanism for responding to OPTIONS requests.
+func IgnoreOptions() CORSOption {
+	return func(ch *cors) error {
+		ch.ignoreOptions = true
+		return nil
+	}
 }

--- a/cors.go
+++ b/cors.go
@@ -1,0 +1,20 @@
+package handlers
+
+import "net/http"
+
+type CORSHandler struct {
+	h    http.Handler
+	opts corsOptions
+}
+
+type corsOptions struct {
+	allowedHeaders []string
+	allowedMethods []string
+	allowedOrigins []string
+	maxAge         int
+	ignoreOptions  bool
+}
+
+func (ch *CORSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+}

--- a/cors_test.go
+++ b/cors_test.go
@@ -1,0 +1,22 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCORSHandler(t *testing.T) {
+	// Test default configuration.
+	r := newRequest("GET", "http://www.example.com/")
+	rr := httptest.NewRecorder()
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	CORS()(testHandler).ServeHTTP(rr, r)
+
+	// TODO(all): Test this more heavily once the defaults are baked in.
+	if status := rr.Code; status != http.StatusOK {
+		t.Fatalf("bad status: got %v want %v", status, http.StatusFound)
+	}
+}


### PR DESCRIPTION
Replacing https://github.com/gorilla/handlers/pull/23

References:
* Mozilla CORS documentation: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS
* W3C Recommendation: http://www.w3.org/TR/cors/
* The existing PR's - starting with #23 - have some of the logic you may wish to re-use.

I envisage the design being similar to the rest of the handlers package: sane defaults out-of-the-box, where 'sane' in this case means 'allows simple requests as per the MDN/W3C docs'.  Also: don't rebase until complete (and I don't mind if we don't rebase at all).

TODO List:
- [ ] Set the default allowed headers, methods and `Content-Type` values out-of-the-box: https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Simple_requests
- [ ] Implement Access-Control-Allow-Origin
- [ ] Implement Access-Control-Expose-Headers
- [ ] Implement Access-Control-Max-Age
- [ ] Implement Access-Control-Allow-Credentials
- [ ] Implement Access-Control-Allow-Methods
- [ ] Implement Access-Control-Allow-Headers
- [ ] Respond to OPTIONS requests & allow passthrough to the underlying handlers/router
- [ ] Test default configuration (i.e. calling `handlers.CORS()(router)`)
- [ ] Test custom configurations via functional options
- [ ] Consider adding an example to the README and/or `doc.go`.

@njohns-grovo has volunteered to work on this, so a huge thanks in advance for that!