### PR TITLE
Bugfix for reusing CORS() configuration with multiple handlers

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -130,9 +130,8 @@ func (ch *cors) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 //  }
 //
 func CORS(opts ...CORSOption) func(http.Handler) http.Handler {
-	ch := parseCORSOptions(opts...)
-
 	return func(h http.Handler) http.Handler {
+		ch := parseCORSOptions(opts...)
 		ch.h = h
 		return ch
 	}

--- a/cors_test.go
+++ b/cors_test.go
@@ -270,3 +270,26 @@ func TestCORSHandlerMultipleAllowOriginsSetsVaryHeader(t *testing.T) {
 		t.Fatalf("bad header: expected %s to be %s, got %s.", corsVaryHeader, corsOriginHeader, header)
 	}
 }
+
+func TestCORSWithMultipleHandlers(t *testing.T) {
+	var lastHandledBy string
+	corsMiddleware := CORS()
+
+	testHandler1 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastHandledBy = "testHandler1"
+	})
+	testHandler2 := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastHandledBy = "testHandler2"
+	})
+
+	r1 := newRequest("GET", "http://www.example.com/")
+	rr1 := httptest.NewRecorder()
+	handler1 := corsMiddleware(testHandler1)
+
+	corsMiddleware(testHandler2)
+
+	handler1.ServeHTTP(rr1, r1)
+	if lastHandledBy != "testHandler1" {
+		t.Fatalf("bad CORS() registration: Handler served should be Handler registered")
+	}
+}


### PR DESCRIPTION
I was running into a weird issue where my re-using of the CORS handler would lead to the wrong handler being called by my mux, and tracked it down to this bug. I noted that in comparably-configured middleware, like [CSRF](https://github.com/gorilla/csrf/blob/master/csrf.go#L123), the factory should set the handler *inside* the closure. 

This branch very simply does just that (+ I added a test, which might be overkill).