### PR TITLE
Adding Origin as a standard whitelisted request header

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -26,7 +26,7 @@ type originValidator func(string) bool
 
 var (
 	defaultCorsMethods = []string{"GET", "HEAD", "POST"}
-	defaultCorsHeaders = []string{"Accept", "Accept-Language", "Content-Language"}
+	defaultCorsHeaders = []string{"Accept", "Accept-Language", "Content-Language", "Origin"}
 )
 
 const (

--- a/cors.go
+++ b/cors.go
@@ -27,6 +27,7 @@ type originValidator func(string) bool
 var (
 	defaultCorsMethods = []string{"GET", "HEAD", "POST"}
 	defaultCorsHeaders = []string{"Accept", "Accept-Language", "Content-Language", "Origin"}
+	// (WebKit/Safari v9 sends the Origin header by default in AJAX requests)
 )
 
 const (


### PR DESCRIPTION
Safari (and I suspect other browsers) will add `Origin` to the list of `Access-Control-Request-Headers` in a CORS request, e.g.:
```
Access-Control-Request-Headers: origin
```

This means that if you don't have this header explicitly permitted, via `handlers.AllowedHeaders`, the request will be 403'd by `gorilla/handlers` at present.

I'd propose instead that `Origin` be included in the list of `defaultCorsHeaders` — I wasn't able to find any document that specifies whether or not this behavior is canon, but it seems that if a major browser behavior relies on it, it'd be better supported as a default.