### PR TITLE
Adds CacheControlHandler

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -398,6 +399,39 @@ func HTTPMethodOverrideHandler(h http.Handler) http.Handler {
 				r.Method = om
 			}
 		}
+		h.ServeHTTP(w, r)
+	})
+}
+
+// CacheControlHandler wraps and returns a http.Handler which checks the url
+// extension and adds a Cache-Control header if valid. Headers will only be
+// added to GET requests. The primary use case would be to wrap a static file
+// server.
+//
+// The maximum age is based on the timings defined in h5bp/server-configs-nginx
+// https://github.com/h5bp/server-configs-nginx/blob/master/h5bp/location/expires.conf
+func CacheControlHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "GET" {
+			var age time.Duration
+			ext := filepath.Ext(r.URL.String())
+
+			switch ext {
+			case ".rss", ".atom":
+				age = time.Hour / time.Second
+			case ".css", ".js":
+				age = (time.Hour * 24 * 365) / time.Second
+			case ".jpg", ".jpeg", ".gif", ".png", ".ico", ".cur", ".gz", ".svg", ".svgz", ".mp4", ".ogg", ".ogv", ".webm", ".htc":
+				age = (time.Hour * 24 * 30) / time.Second
+			default:
+				age = 0
+			}
+
+			if age > 0 {
+				w.Header().Add("Cache-Control", fmt.Sprintf("max-age=%d, public, must-revalidate, proxy-revalidate", age))
+			}
+		}
+
 		h.ServeHTTP(w, r)
 	})
 }


### PR DESCRIPTION
Adds `CacheControlHandler` which sets the `Cache-Control` header based on file extension.

I haven't added any documentation or tests yet, just wanted to check if my approach is correct and falls inline with the other Gorilla packages and code before going too far :)
