### PR TITLE
Removes call to WriteHeader

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -22,7 +22,6 @@ type compressResponseWriter struct {
 
 func (w *compressResponseWriter) WriteHeader(c int) {
 	w.ResponseWriter.Header().Del("Content-Length")
-	w.ResponseWriter.WriteHeader(c)
 }
 
 func (w *compressResponseWriter) Header() http.Header {


### PR DESCRIPTION
I'm completely out of my depth here, but this is a potential fix for https://github.com/gorilla/handlers/issues/83. Interestingly enough, the entire WriteHeader method can be removed and tests still pass.