### PR TITLE
Add note about the CompressHandler and TLS traffic

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -56,6 +56,9 @@ func (w *compressResponseWriter) Flush() {
 
 // CompressHandler gzip compresses HTTP responses for clients that support it
 // via the 'Accept-Encoding' header.
+//
+// Compressing TLS traffic may leak the page contents to an attacker if the
+// page contains user input: http://security.stackexchange.com/a/102015/12208
 func CompressHandler(h http.Handler) http.Handler {
 	return CompressHandlerLevel(h, gzip.DefaultCompression)
 }


### PR DESCRIPTION
The BEAST and CRIME attacks both let an attacker extract secrets from a page
by making guesses about the page's contents, and then measuring how much the
response compresses. It is probably worthwhile to warn users about the side
effects of compressing responses if they contain secret information.

For more information, see http://security.stackexchange.com/a/102015/12208.