### PR TITLE
Set url.URL Host to X-Forwarded-Host

### DIFF
--- a/proxy_headers.go
+++ b/proxy_headers.go
@@ -51,10 +51,15 @@ func ProxyHeaders(h http.Handler) http.Handler {
 		if scheme := getScheme(r); scheme != "" {
 			r.URL.Scheme = scheme
 		}
+
 		// Set the host with the value passed by the proxy
-		if r.Header.Get(xForwardedHost) != "" {
-			r.Host = r.Header.Get(xForwardedHost)
+		if forwardedHost := r.Header.Get(xForwardedHost); forwardedHost != "" {
+			r.Host = forwardedHost
+			if r.URL.Host == "" {
+				r.URL.Host = forwardedHost
+			}
 		}
+
 		// Call the next handler in the chain.
 		h.ServeHTTP(w, r)
 	}

--- a/proxy_headers_test.go
+++ b/proxy_headers_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 )
 
@@ -79,14 +80,14 @@ func TestProxyHeaders(t *testing.T) {
 	r.Header.Set(xForwardedProto, "https")
 	r.Header.Set(xForwardedHost, "google.com")
 	var (
-		addr  string
-		proto string
-		host  string
+		addr string
+		host string
+		url  *url.URL
 	)
 	ProxyHeaders(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			addr = r.RemoteAddr
-			proto = r.URL.Scheme
+			url = r.URL
 			host = r.Host
 		})).ServeHTTP(rr, r)
 
@@ -99,13 +100,18 @@ func TestProxyHeaders(t *testing.T) {
 			r.Header.Get(xForwardedFor))
 	}
 
-	if proto != r.Header.Get(xForwardedProto) {
-		t.Fatalf("wrong address: got %s want %s", proto,
-			r.Header.Get(xForwardedProto))
-	}
-	if host != r.Header.Get(xForwardedHost) {
+	if host := url.Host; host != r.Header.Get(xForwardedHost) {
 		t.Fatalf("wrong address: got %s want %s", host,
 			r.Header.Get(xForwardedHost))
 	}
 
+	if proto := url.Scheme; proto != r.Header.Get(xForwardedProto) {
+		t.Fatalf("wrong scheme: got %s want %s", proto,
+			r.Header.Get(xForwardedProto))
+	}
+
+	if host != r.Header.Get(xForwardedHost) {
+		t.Fatalf("wrong address: got %s want %s", host,
+			r.Header.Get(xForwardedHost))
+	}
 }


### PR DESCRIPTION
The `http.Request.URL` in net/http defaults to the URI, which only
has the path information (no scheme, no userinfo, no host). This
causes errors with CSRF protection using `csrf.Protect`, because
the `url` looks like: `https:///app/path` (because `r.URL` starts as
`/app/path` and a scheme is attached).

This change causes the URL to be updated with the value from
`X-Forwarded-Host`, which fixes the case where `ProxyHeaders`
is used together with `csrf.Protect`, however it is only a partial
fix. `csrf.Protect` also needs to be updated separately to handle
the URL returned by http.Request.

Signed-off-by: Jonathan Yu <jawnsy@cpan.org>