### PR TITLE
(Combined)LoggingHandler: Add Go 1.8 http.Pusher support

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -94,7 +94,7 @@ func makeLogger(w http.ResponseWriter) loggingResponseWriter {
 	return logger
 }
 
-type loggingResponseWriter interface {
+type commonLoggingResponseWriter interface {
 	http.ResponseWriter
 	http.Flusher
 	Status() int

--- a/handlers_go18.go
+++ b/handlers_go18.go
@@ -1,0 +1,21 @@
+// +build go1.8
+
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type loggingResponseWriter interface {
+	commonLoggingResponseWriter
+	http.Pusher
+}
+
+func (l *responseLogger) Push(target string, opts *http.PushOptions) error {
+	p, ok := l.w.(http.Pusher)
+	if !ok {
+		return fmt.Errorf("responseLogger does not implement http.Pusher")
+	}
+	return p.Push(target, opts)
+}

--- a/handlers_go18_test.go
+++ b/handlers_go18_test.go
@@ -1,0 +1,34 @@
+// +build go1.8
+
+package handlers
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLoggingHandlerWithPush(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if _, ok := w.(http.Pusher); !ok {
+			t.Fatalf("%T from LoggingHandler does not satisfy http.Pusher interface when built with Go >=1.8", w)
+		}
+		w.WriteHeader(200)
+	})
+
+	logger := LoggingHandler(ioutil.Discard, handler)
+	logger.ServeHTTP(httptest.NewRecorder(), newRequest("GET", "/"))
+}
+
+func TestCombinedLoggingHandlerWithPush(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if _, ok := w.(http.Pusher); !ok {
+			t.Fatalf("%T from CombinedLoggingHandler does not satisfy http.Pusher interface when built with Go >=1.8", w)
+		}
+		w.WriteHeader(200)
+	})
+
+	logger := CombinedLoggingHandler(ioutil.Discard, handler)
+	logger.ServeHTTP(httptest.NewRecorder(), newRequest("GET", "/"))
+}

--- a/handlers_pre18.go
+++ b/handlers_pre18.go
@@ -1,0 +1,7 @@
+// +build !go1.8
+
+package handlers
+
+type loggingResponseWriter interface {
+	commonLoggingResponseWriter
+}


### PR DESCRIPTION
When building with Go 1.8, embed http.Pusher interface in
loggingResponseWriter interface and define a Push wrapper method on
responseLogger.  Without this change, users of handlers.LoggingHandler
or handlers.CombinedLoggingHandler cannot take advantage of the new
http.Pusher interface.

When building with pre-1.8 Go, the loggingResponseWriter and
responseLogger types remain unchanged.