### PR TITLE
Add AllowedOriginRegexValidator

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -230,6 +231,19 @@ func AllowedOrigins(origins []string) CORSOption {
 func AllowedOriginValidator(fn OriginValidator) CORSOption {
 	return func(ch *cors) error {
 		ch.allowedOriginValidator = fn
+		return nil
+	}
+}
+
+// AllowedOriginValidator validates urls against a regular expression for evaluating allowed origins in CORS requests, represented by the
+// 'Allow-Access-Control-Origin' HTTP header.
+func AllowedOriginRegexValidator(rgx string) CORSOption {
+	r := regexp.MustCompile(rgx)
+
+	return func(ch *cors) error {
+		ch.allowedOriginValidator = func(url string) bool {
+			return r.MatchString(url)
+		}
 		return nil
 	}
 }

--- a/cors.go
+++ b/cors.go
@@ -239,7 +239,6 @@ func AllowedOriginValidator(fn OriginValidator) CORSOption {
 // 'Allow-Access-Control-Origin' HTTP header.
 func AllowedOriginRegexValidator(rgx string) CORSOption {
 	r := regexp.MustCompile(rgx)
-
 	return func(ch *cors) error {
 		ch.allowedOriginValidator = func(url string) bool {
 			return r.MatchString(url)

--- a/cors_test.go
+++ b/cors_test.go
@@ -332,5 +332,18 @@ func TestCORSHandlerWithCustomValidator(t *testing.T) {
 	if header != r.URL.String() {
 		t.Fatalf("bad header: expected %s to be %s, got %s.", corsAllowOriginHeader, r.URL.String(), header)
 	}
+}
 
+func TestCORSHandlerWithRegexValidator(t *testing.T) {
+	r := newRequest("GET", "http://abcd.example.com")
+	r.Header.Set("Origin", r.URL.String())
+	rr := httptest.NewRecorder()
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	CORS(AllowedOriginRegexValidator(".*.example.com"))(testHandler).ServeHTTP(rr, r)
+	header := rr.HeaderMap.Get(corsAllowOriginHeader)
+	if header != r.URL.String() {
+		t.Fatalf("bad header: expected %s to be %s, got %s.", corsAllowOriginHeader, r.URL.String(), header)
+	}
 }


### PR DESCRIPTION
It's a helper method that compiles a user-provided regular expression and then validates passed urls against that.

After needing this functionality on some of my projects, I decided to integrate it into handlers.