### PR TITLE
Add Vary header when allowedOrigins is *

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -106,7 +106,7 @@ func (ch *cors) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(corsAllowCredentialsHeader, "true")
 	}
 
-	if len(ch.allowedOrigins) > 1 {
+	if len(ch.allowedOrigins) > 1 || ch.allowedOrigins[0] == corsOriginMatchAll {
 		w.Header().Set(corsVaryHeader, corsOriginHeader)
 	}
 


### PR DESCRIPTION
This fixes a caching issue when multiple domains access the same resource.

Related:
https://bugs.chromium.org/p/chromium/issues/detail?id=260239