### PR TITLE
Revert "Add Vary header when allowedOrigins is * (#114)"

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -106,7 +106,7 @@ func (ch *cors) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(corsAllowCredentialsHeader, "true")
 	}
 
-	if len(ch.allowedOrigins) > 1 || ch.allowedOrigins[0] == corsOriginMatchAll {
+	if len(ch.allowedOrigins) > 1 {
 		w.Header().Set(corsVaryHeader, corsOriginHeader)
 	}
 


### PR DESCRIPTION
This reverts commit 9327cfd519a30293fcbc6b808b6e387ba3d27bd8.

```
=== RUN   TestDefaultCORSHandlerReturnsOkWithOrigin
--- FAIL: TestDefaultCORSHandlerReturnsOkWithOrigin (0.00s)
panic: runtime error: index out of range [recovered]
	panic: runtime error: index out of range
goroutine 16 [running]:
testing.tRunner.func1(0xc42007c0d0)
	/home/travis/.gimme/versions/go1.8.linux.amd64/src/testing/testing.go:622 +0x55f
panic(0x81b720, 0xa3e440)
	/home/travis/.gimme/versions/go1.8.linux.amd64/src/runtime/panic.go:489 +0x2f0
github.com/gorilla/handlers.(*cors).ServeHTTP(0xc4200c41b0, 0xa19840, 0xc42007a0c0, 0xc4200ac100)
	/home/travis/gopath/src/github.com/gorilla/handlers/cors.go:109 +0x4f0
github.com/gorilla/handlers.TestDefaultCORSHandlerReturnsOkWithOrigin(0xc42007c0d0)
	/home/travis/gopath/src/github.com/gorilla/handlers/cors_test.go:31 +0x296
testing.tRunner(0xc42007c0d0, 0x8869a0)
	/home/travis/.gimme/versions/go1.8.linux.amd64/src/testing/testing.go:657 +0x108
created by testing.(*T).Run
	/home/travis/.gimme/versions/go1.8.linux.amd64/src/testing/testing.go:697 +0x544
exit status 2
FAIL	github.com/gorilla/handlers	0.224s
```