### PR TITLE
allow X-Remote-User header to determine username if not set in URL

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -241,6 +241,8 @@ func buildCommonLogLine(req *http.Request, url url.URL, ts time.Time, status int
 		if name := url.User.Username(); name != "" {
 			username = name
 		}
+	} else if name := req.Header.Get("X-Remote-User"); name != "" {
+		username = name
 	}
 
 	host, _, err := net.SplitHostPort(req.RemoteAddr)


### PR DESCRIPTION
right now for the log handler the code is using the username passed in as part of the URL to determine who sent a request to the web server. People who use auth schemes often set a header for this info. This small change will allow for this to flow through to the logs.