### PR TITLE
fix test for allow methods header

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -96,7 +96,7 @@ func (ch *cors) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set(corsMaxAgeHeader, strconv.Itoa(ch.maxAge))
 		}
 
-		if !ch.isMatch(method, defaultCorsMethods) {
+		if ch.isMatch(method, ch.allowedMethods) {
 			w.Header().Set(corsAllowMethodsHeader, method)
 		}
 	} else {


### PR DESCRIPTION
I was not able to use CORS without reversing the logic for including Access-Control-Allow-Methods.
At the same time I also allowed you to customize the list of requested methods that you can get this header for.
My client would send Access-Control-Request-Method in an OPTIONS call and expect the corresponding Access-Control-Allow-Methods.
With regards to the default list, my server doesn't implement HEAD but does implement PUT and DELETE.
I don't know which of these new ones might generate an OPTIONS request, so I'm supplied a list that includes them.
Let me know what you think.