### PR TITLE
[cors] add OPTIONS status code + fix function typo

### DIFF
--- a/cors_test.go
+++ b/cors_test.go
@@ -122,6 +122,25 @@ func TestCORSHandlerOptionsRequestMustNotBePassedToNextHandler(t *testing.T) {
 	}
 }
 
+func TestCORSHandlerOptionsRequestMustNotBePassedToNextHandlerWithCustomStatusCode(t *testing.T) {
+	statusCode := 204
+	r := newRequest("OPTIONS", "http://www.example.com/")
+	r.Header.Set("Origin", r.URL.String())
+	r.Header.Set(corsRequestMethodHeader, "GET")
+
+	rr := httptest.NewRecorder()
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("Options request must not be passed to next handler")
+	})
+
+	CORS(OptionStatusCode(statusCode))(testHandler).ServeHTTP(rr, r)
+
+	if status := rr.Code; status != statusCode {
+		t.Fatalf("bad status: got %v want %v", status, http.StatusOK)
+	}
+}
+
 func TestCORSHandlerOptionsRequestMustNotBePassedToNextHandlerWhenOriginNotAllowed(t *testing.T) {
 	r := newRequest("OPTIONS", "http://www.example.com/")
 	r.Header.Set("Origin", r.URL.String())


### PR DESCRIPTION
I believe we should handle the StatusCode when receiving OPTIONS requests. Best practice is to respond with a `200` or `204` code.

`200` code seems to be the most used since it seems to work across any browser:
https://stackoverflow.com/questions/46026409/what-are-proper-status-codes-for-cors-preflight-requests

We should let the user override this status code this is why I exposed the `OptionStatusCode` method that take an int.