### PR TITLE
Feature: add AllowFallthrough CORSOption

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -19,6 +19,7 @@ type cors struct {
 	maxAge                 int
 	ignoreOptions          bool
 	allowCredentials       bool
+	allowFallthrough       bool
 	optionStatusCode       int
 }
 
@@ -131,7 +132,7 @@ func (ch *cors) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set(corsAllowOriginHeader, returnOrigin)
 
-	if r.Method == corsOptionMethod {
+	if r.Method == corsOptionMethod && !ch.allowFallthrough {
 		w.WriteHeader(ch.optionStatusCode)
 		return
 	}
@@ -318,6 +319,15 @@ func IgnoreOptions() CORSOption {
 func AllowCredentials() CORSOption {
 	return func(ch *cors) error {
 		ch.allowCredentials = true
+		return nil
+	}
+}
+
+// AllowFallthrough can be used to make sure OPTION request calls the next
+// middleware. This is useful when you need to add custom headers in addition to CORS headers.
+func AllowFallthrough() CORSOption {
+	return func(ch *cors) error {
+		ch.allowFallthrough = true
 		return nil
 	}
 }

--- a/cors_test.go
+++ b/cors_test.go
@@ -408,3 +408,20 @@ func TestCORSAllowStar(t *testing.T) {
 		t.Fatalf("bad header: expected %s to be %s, got %s.", corsAllowOriginHeader, "*", header)
 	}
 }
+
+func TestCORSHandlerAllowFallthroughFallsThrough(t *testing.T) {
+	r := newRequest("OPTIONS", "http://www.example.com/")
+	r.Header.Set("Origin", r.URL.String())
+	r.Header.Set(corsRequestMethodHeader, "GET")
+	rr := httptest.NewRecorder()
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Custom-Header", "Custom-Value")
+	})
+
+	CORS(AllowFallthrough())(testHandler).ServeHTTP(rr, r)
+
+	if customHeader := rr.Header().Get("Custom-Header"); customHeader != "Custom-Value" {
+		t.Fatalf("bad header: got %v want %v", customHeader, "Custom-Value")
+	}
+}


### PR DESCRIPTION
This PR:

* Adds `AllowFallthrough` option will make sure we call the next middleware for OPTIONS request

In addition to CORS, `OPTIONS` request is sometimes being used to gather additional information about the server and the server has to respond with a custom header.

In this case I need both, CORS and additional app specific headers, in the response. Right now, CORS middleware will just return early for all `OPTIONS` requests.

An example would be TUS resumable-upload, where the client will send `OPTIONS` request to get TUS version and what extensions does the server support.

https://tus.io/protocols/resumable-upload.html#options
