### PR TITLE
export buildCommonLogLine (and appendQuoted)

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -80,7 +80,7 @@ type commonLoggingResponseWriter interface {
 
 const lowerhex = "0123456789abcdef"
 
-func appendQuoted(buf []byte, s string) []byte {
+func AppendQuoted(buf []byte, s string) []byte {
 	var runeTmp [utf8.UTFMax]byte
 	for width := 0; len(s) > 0; s = s[width:] {
 		r := rune(s[0])
@@ -145,10 +145,10 @@ func appendQuoted(buf []byte, s string) []byte {
 
 }
 
-// buildCommonLogLine builds a log entry for req in Apache Common Log Format.
+// BuildCommonLogLine builds a log entry for req in Apache Common Log Format.
 // ts is the timestamp with which the entry should be logged.
 // status and size are used to provide the response HTTP status and size.
-func buildCommonLogLine(req *http.Request, url url.URL, ts time.Time, status int, size int) []byte {
+func BuildCommonLogLine(req *http.Request, url url.URL, ts time.Time, status int, size int) []byte {
 	username := "-"
 	if url.User != nil {
 		if name := url.User.Username(); name != "" {
@@ -183,7 +183,7 @@ func buildCommonLogLine(req *http.Request, url url.URL, ts time.Time, status int
 	buf = append(buf, `] "`...)
 	buf = append(buf, req.Method...)
 	buf = append(buf, " "...)
-	buf = appendQuoted(buf, uri)
+	buf = AppendQuoted(buf, uri)
 	buf = append(buf, " "...)
 	buf = append(buf, req.Proto...)
 	buf = append(buf, `" `...)
@@ -197,7 +197,7 @@ func buildCommonLogLine(req *http.Request, url url.URL, ts time.Time, status int
 // ts is the timestamp with which the entry should be logged.
 // status and size are used to provide the response HTTP status and size.
 func writeLog(writer io.Writer, params LogFormatterParams) {
-	buf := buildCommonLogLine(params.Request, params.URL, params.TimeStamp, params.StatusCode, params.Size)
+	buf := BuildCommonLogLine(params.Request, params.URL, params.TimeStamp, params.StatusCode, params.Size)
 	buf = append(buf, '\n')
 	writer.Write(buf)
 }
@@ -206,11 +206,11 @@ func writeLog(writer io.Writer, params LogFormatterParams) {
 // ts is the timestamp with which the entry should be logged.
 // status and size are used to provide the response HTTP status and size.
 func writeCombinedLog(writer io.Writer, params LogFormatterParams) {
-	buf := buildCommonLogLine(params.Request, params.URL, params.TimeStamp, params.StatusCode, params.Size)
+	buf := BuildCommonLogLine(params.Request, params.URL, params.TimeStamp, params.StatusCode, params.Size)
 	buf = append(buf, ` "`...)
-	buf = appendQuoted(buf, params.Request.Referer())
+	buf = AppendQuoted(buf, params.Request.Referer())
 	buf = append(buf, `" "`...)
-	buf = appendQuoted(buf, params.Request.UserAgent())
+	buf = AppendQuoted(buf, params.Request.UserAgent())
 	buf = append(buf, '"', '\n')
 	writer.Write(buf)
 }


### PR DESCRIPTION
`buildCommonLogLine` is very useful but it is unexported.
I want to customize CombinedLogFormat.

```go
package mypackage

func customLog(writer io.Writer, params handlers.LogFormatterParams) {
	buf := handlers.BuildCommonLogLine(params.Request, params.URL, params.TimeStamp, params.StatusCode, params.Size) // want
	buf = append(buf, ` "`...)
	buf = handlers.AppendQuoted(buf, params.Request.Referer())
	buf = append(buf, `" "`...)
	buf = handlers.AppendQuoted(buf, params.Request.UserAgent())
	/* custom something */
	buf = append(buf, '"', '\n')
	writer.Write(buf)
}
```