### PR TITLE
RecoveryHandler should not handle http.ErrAbortHandler.

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -69,7 +69,7 @@ func PrintRecoveryStack(print bool) RecoveryOption {
 
 func (h recoveryHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	defer func() {
-		if err := recover(); err != nil {
+		if err := recover(); err != nil && err != http.ErrAbortHandler {
 			w.WriteHeader(http.StatusInternalServerError)
 			h.log(err)
 		}

--- a/recovery_test.go
+++ b/recovery_test.go
@@ -42,3 +42,20 @@ func TestRecoveryLoggerWithCustomLogger(t *testing.T) {
 		t.Fatalf("Got log %#v, wanted substring %#v", buf.String(), "Unexpected error!")
 	}
 }
+
+func TestRecoveryLoggerSkipsHttpErrAbortHandler(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+
+	handler := RecoveryHandler()
+	handlerFunc := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		panic(http.ErrAbortHandler)
+	})
+
+	recovery := handler(handlerFunc)
+	recovery.ServeHTTP(httptest.NewRecorder(), newRequest("GET", "/subdir/asdf"))
+
+	if buf.String() != "" {
+		t.Fatalf("Got log %#v, wanted empty string", buf.String())
+	}
+}


### PR DESCRIPTION
Based on discussion https://github.com/golang/go/issues/28239 .