### PR TITLE
Cleanup properly after hijacking a request

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -43,6 +43,9 @@ func (h loggingHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	url := *req.URL
 
 	h.handler.ServeHTTP(logger, req)
+	if req.MultipartForm != nil {
+		req.MultipartForm.RemoveAll()
+	}
 
 	params := LogFormatterParams{
 		Request:    req,


### PR DESCRIPTION
The logging handler hijacks the HTTP request, but does
not properly clean up the files left behind by multipart
forms.

The HTTP library normally does this, but if the connection is hijacked,
all responsibility to clean up is on the hijacker.

**Summary of Changes**

1. Properly clean up multipart form disk artifacts after hijacking a connection.
