### PR TITLE
Add ProxyHeadersFromTrusted handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/gorilla/handlers
+
+go 1.12

--- a/proxy_headers.go
+++ b/proxy_headers.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"net"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,14 +57,17 @@ func ProxyHeaders(h http.Handler) http.Handler {
 // source
 func ProxyHeadersFromTrusted(h http.Handler, trusted []string) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-		// Check trusted list
-		for _, t := range trusted {
-			if r.RemoteAddr == t {
-				// Update the request.
-				r = updateRequest(r)
+		// Get source ip from r.RemoteAddr
+		if src, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+			// Loop through list of trusted sources
+			for _, t := range trusted {
+				if src == t {
+					// Update the request.
+					r = updateRequest(r)
 
-				// Finish the loop
-				break
+					// Finish the loop
+					break
+				}
 			}
 		}
 		// Call the next handler in the chain.

--- a/proxy_headers_test.go
+++ b/proxy_headers_test.go
@@ -171,11 +171,11 @@ func TestProxyHeadersFromTrusted(t *testing.T) {
 		source       string
 		expectChange bool
 	}{
-		{[]string{}, "1.2.3.4", false},
-		{[]string{"8.8.8.8"}, "1.2.3.4", false},
-		{[]string{"1.2.3.4"}, "1.2.3.4", true},
-		{[]string{"8.8.8.8", "1.2.3.4"}, "1.2.3.4", true},
-		{[]string{"1.2.3.4", "8.8.8.8"}, "1.2.3.4", true},
+		{[]string{}, "1.2.3.4:8000", false},
+		{[]string{"8.8.8.8"}, "1.2.3.4:8000", false},
+		{[]string{"1.2.3.4"}, "1.2.3.4:8000", true},
+		{[]string{"8.8.8.8", "1.2.3.4"}, "1.2.3.4:8000", true},
+		{[]string{"1.2.3.4", "8.8.8.8"}, "1.2.3.4:8000", true},
 	}
 	for _, tt := range tests {
 		rr := httptest.NewRecorder()

--- a/proxy_headers_test.go
+++ b/proxy_headers_test.go
@@ -172,7 +172,10 @@ func TestProxyHeadersFromTrusted(t *testing.T) {
 		expectChange bool
 	}{
 		{[]string{}, "1.2.3.4", false},
+		{[]string{"8.8.8.8"}, "1.2.3.4", false},
 		{[]string{"1.2.3.4"}, "1.2.3.4", true},
+		{[]string{"8.8.8.8", "1.2.3.4"}, "1.2.3.4", true},
+		{[]string{"1.2.3.4", "8.8.8.8"}, "1.2.3.4", true},
 	}
 	for _, tt := range tests {
 		rr := httptest.NewRecorder()


### PR DESCRIPTION
**Summary of Changes**

1. Adds a new handler named ProxyHeadersFromTrusted that does the same job as ProxyHeaders however only from trusted sources

The new handler is provided with a list of trusted IP addresses, such as an organisations reverse proxies/load balancers which must match before any changes are made to the http.Request.

Only IP addresses will be matched in the trusted IP list. 
