### PR TITLE
Support logger for print stack trace

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"log"
 	"net/http"
-	"os"
 	"runtime/debug"
 )
 
@@ -87,11 +86,11 @@ func (h recoveryHandler) log(v ...interface{}) {
 	}
 
 	if h.printStack {
-		stack := debug.Stack()
+		stack := string(debug.Stack())
 		if h.logger != nil {
-			h.logger.Println(string(stack))
+			h.logger.Println(stack)
 		} else {
-			_, _ = os.Stderr.Write(stack)
+			log.Println(stack)
 		}
 	}
 }

--- a/recovery.go
+++ b/recovery.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"log"
 	"net/http"
+	"os"
 	"runtime/debug"
 )
 
@@ -19,7 +20,7 @@ type recoveryHandler struct {
 
 // RecoveryOption provides a functional approach to define
 // configuration for a handler; such as setting the logging
-// whether or not to print strack traces on panic.
+// whether or not to print stack traces on panic.
 type RecoveryOption func(http.Handler)
 
 func parseRecoveryOptions(h http.Handler, opts ...RecoveryOption) http.Handler {
@@ -86,6 +87,11 @@ func (h recoveryHandler) log(v ...interface{}) {
 	}
 
 	if h.printStack {
-		debug.PrintStack()
+		stack := debug.Stack()
+		if h.logger != nil {
+			h.logger.Println(string(stack))
+		} else {
+			_, _ = os.Stderr.Write(stack)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #171 

**Summary of Changes**

Use `logger` if available for stack trace. If not, we will still print stacktrace to stdout as usual.

> PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!
