### PR TITLE
[compress] Vary: Accept-Encoding must always be set

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 )
 
+const acceptEncoding string = "Accept-Encoding"
+
 type compressResponseWriter struct {
 	io.Writer
 	http.ResponseWriter
@@ -82,7 +84,7 @@ func CompressHandlerLevel(h http.Handler, level int) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// detect what encoding to use
 		var encoding string
-		for _, curEnc := range strings.Split(r.Header.Get("Accept-Encoding"), ",") {
+		for _, curEnc := range strings.Split(r.Header.Get(acceptEncoding), ",") {
 			curEnc = strings.TrimSpace(curEnc)
 			if curEnc == gzipEncoding || curEnc == flateEncoding {
 				encoding = curEnc
@@ -91,7 +93,7 @@ func CompressHandlerLevel(h http.Handler, level int) http.Handler {
 		}
 
 		// always add Accept-Encoding to Vary to prevent intermediate caches corruption
-		w.Header().Add("Vary", "Accept-Encoding")
+		w.Header().Add("Vary", acceptEncoding)
 
 		// if we weren't able to identify an encoding we're familiar with, pass on the
 		// request to the handler and return
@@ -110,7 +112,7 @@ func CompressHandlerLevel(h http.Handler, level int) http.Handler {
 		defer encWriter.Close()
 
 		w.Header().Set("Content-Encoding", encoding)
-		r.Header.Del("Accept-Encoding")
+		r.Header.Del(acceptEncoding)
 
 		hijacker, ok := w.(http.Hijacker)
 		if !ok { /* w is not Hijacker... oh well... */

--- a/compress.go
+++ b/compress.go
@@ -90,6 +90,9 @@ func CompressHandlerLevel(h http.Handler, level int) http.Handler {
 			}
 		}
 
+		// always add Accept-Encoding to Vary to prevent intermediate caches corruption
+		w.Header().Add("Vary", "Accept-Encoding")
+
 		// if we weren't able to identify an encoding we're familiar with, pass on the
 		// request to the handler and return
 		if encoding == "" {
@@ -108,7 +111,6 @@ func CompressHandlerLevel(h http.Handler, level int) http.Handler {
 
 		w.Header().Set("Content-Encoding", encoding)
 		r.Header.Del("Accept-Encoding")
-		w.Header().Add("Vary", "Accept-Encoding")
 
 		hijacker, ok := w.(http.Hijacker)
 		if !ok { /* w is not Hijacker... oh well... */

--- a/compress_test.go
+++ b/compress_test.go
@@ -47,6 +47,9 @@ func TestCompressHandlerNoCompression(t *testing.T) {
 	if l := w.HeaderMap.Get("Content-Length"); l != "9216" {
 		t.Errorf("wrong content-length. got %q expected %d", l, 1024*9)
 	}
+	if v := w.HeaderMap.Get("Vary"); v != "Accept-Encoding" {
+		t.Errorf("wrong vary. got %s expected %s", v, "Accept-Encoding")
+	}
 }
 
 func TestAcceptEncodingIsDropped(t *testing.T) {

--- a/compress_test.go
+++ b/compress_test.go
@@ -26,7 +26,7 @@ func compressedRequest(w *httptest.ResponseRecorder, compression string) {
 	})).ServeHTTP(w, &http.Request{
 		Method: "GET",
 		Header: http.Header{
-			"Accept-Encoding": []string{compression},
+			acceptEncoding: []string{compression},
 		},
 	})
 
@@ -47,8 +47,8 @@ func TestCompressHandlerNoCompression(t *testing.T) {
 	if l := w.HeaderMap.Get("Content-Length"); l != "9216" {
 		t.Errorf("wrong content-length. got %q expected %d", l, 1024*9)
 	}
-	if v := w.HeaderMap.Get("Vary"); v != "Accept-Encoding" {
-		t.Errorf("wrong vary. got %s expected %s", v, "Accept-Encoding")
+	if v := w.HeaderMap.Get("Vary"); v != acceptEncoding {
+		t.Errorf("wrong vary. got %s expected %s", v, acceptEncoding)
 	}
 }
 
@@ -93,7 +93,7 @@ func TestAcceptEncodingIsDropped(t *testing.T) {
 
 	for _, tCase := range tCases {
 		ch := CompressHandler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			acceptEnc := r.Header.Get("Accept-Encoding")
+			acceptEnc := r.Header.Get(acceptEncoding)
 			if acceptEnc == "" && tCase.isPresent {
 				t.Fatalf("%s: expected 'Accept-Encoding' header to be present but was not", tCase.name)
 			}
@@ -111,7 +111,7 @@ func TestAcceptEncodingIsDropped(t *testing.T) {
 		ch.ServeHTTP(w, &http.Request{
 			Method: "GET",
 			Header: http.Header{
-				"Accept-Encoding": []string{tCase.compression},
+				acceptEncoding: []string{tCase.compression},
 			},
 		})
 	}
@@ -192,7 +192,7 @@ func TestCompressHandlerPreserveInterfaces(t *testing.T) {
 		_ http.Hijacker      = fullyFeaturedResponseWriter{}
 	)
 	var h http.Handler = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		comp := r.Header.Get("Accept-Encoding")
+		comp := r.Header.Get(acceptEncoding)
 		if _, ok := rw.(*compressResponseWriter); !ok {
 			t.Fatalf("ResponseWriter wasn't wrapped by compressResponseWriter, got %T type", rw)
 		}
@@ -214,9 +214,9 @@ func TestCompressHandlerPreserveInterfaces(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create test request: %v", err)
 	}
-	r.Header.Set("Accept-Encoding", "gzip")
+	r.Header.Set(acceptEncoding, "gzip")
 	h.ServeHTTP(rw, r)
 
-	r.Header.Set("Accept-Encoding", "deflate")
+	r.Header.Set(acceptEncoding, "deflate")
 	h.ServeHTTP(rw, r)
 }


### PR DESCRIPTION
**Summary of Changes**

`Vary: Content-Encoding` must always be set, even if the client doesn't support compression, to prevent corruption of intermediate caches such as Varnish.

This bug has been reported by @nicolas-grekas while working with Vulcain.rocks. Fun fact: Nicolas reported the exact same bug to PHP... [12 years ago](https://bugs.php.net/bug.php?id=40325) 🙂