### PR TITLE
Support logger for print stack trace

### DIFF
--- a/recovery.go
+++ b/recovery.go
@@ -19,7 +19,7 @@ type recoveryHandler struct {
 
 // RecoveryOption provides a functional approach to define
 // configuration for a handler; such as setting the logging
-// whether or not to print strack traces on panic.
+// whether or not to print stack traces on panic.
 type RecoveryOption func(http.Handler)
 
 func parseRecoveryOptions(h http.Handler, opts ...RecoveryOption) http.Handler {
@@ -86,6 +86,11 @@ func (h recoveryHandler) log(v ...interface{}) {
 	}
 
 	if h.printStack {
-		debug.PrintStack()
+		stack := string(debug.Stack())
+		if h.logger != nil {
+			h.logger.Println(stack)
+		} else {
+			log.Println(stack)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #171

**Summary of Changes**

1. Use logger if available for stack trace. If not, we will still print stacktrace to stdout as usual.

> PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!
