### PR TITLE
Fix compression of *os.Files.

### DIFF
--- a/compress.go
+++ b/compress.go
@@ -36,6 +36,10 @@ func (cw *compressResponseWriter) Write(b []byte) (int, error) {
 	return cw.compressor.Write(b)
 }
 
+func (cw *compressResponseWriter) ReadFrom(r io.Reader) (int64, error) {
+	return io.Copy(cw.compressor, r)
+}
+
 type flusher interface {
 	Flush() error
 }
@@ -128,6 +132,9 @@ func CompressHandlerLevel(h http.Handler, level int) http.Handler {
 			},
 			Flush: func(httpsnoop.FlushFunc) httpsnoop.FlushFunc {
 				return cw.Flush
+			},
+			ReadFrom: func(rff httpsnoop.ReadFromFunc) httpsnoop.ReadFromFunc {
+				return cw.ReadFrom
 			},
 		})
 


### PR DESCRIPTION
After using httpsnoop to preserve interfaces, the compress response
writer now implemented ReaderFrom. ReaderFrom is used by net/http to
use sendfile when serving *os.Files. This breaks compression because
it serves directly to the underlying response writer, skipping the
compressor. Fix by implementing ReadFrom on our resposne writer to
copy to our compressor.

Fixes #194.
