### PR TITLE
Handle multiple hosts in X-Forwarded-Host header

### DIFF
--- a/proxy_headers.go
+++ b/proxy_headers.go
@@ -51,9 +51,10 @@ func ProxyHeaders(h http.Handler) http.Handler {
 		if scheme := getScheme(r); scheme != "" {
 			r.URL.Scheme = scheme
 		}
-		// Set the host with the value passed by the proxy
-		if r.Header.Get(xForwardedHost) != "" {
-			r.Host = r.Header.Get(xForwardedHost)
+		// Set the host with the value passed by the first proxy
+		if forwardedHost := r.Header.Get(xForwardedHost); forwardedHost != "" {
+			forwardedHostSlice := strings.Split(forwardedHost, ",")
+			r.Host = strings.TrimSpace(forwardedHostSlice[0])
 		}
 		// Call the next handler in the chain.
 		h.ServeHTTP(w, r)

--- a/proxy_headers_test.go
+++ b/proxy_headers_test.go
@@ -77,7 +77,7 @@ func TestProxyHeaders(t *testing.T) {
 
 	r.Header.Set(xForwardedFor, "8.8.8.8")
 	r.Header.Set(xForwardedProto, "https")
-	r.Header.Set(xForwardedHost, "google.com")
+	r.Header.Set(xForwardedHost, "google.com, anotherproxy, onemore")
 	var (
 		addr  string
 		proto string
@@ -103,9 +103,8 @@ func TestProxyHeaders(t *testing.T) {
 		t.Fatalf("wrong address: got %s want %s", proto,
 			r.Header.Get(xForwardedProto))
 	}
-	if host != r.Header.Get(xForwardedHost) {
-		t.Fatalf("wrong address: got %s want %s", host,
-			r.Header.Get(xForwardedHost))
+	if host != "google.com" {
+		t.Fatalf("wrong address: got %s want %s", host, "google.com")
 	}
 
 }


### PR DESCRIPTION
When multiple reverse-proxies are stacked, the `X-Forwarded-Host` header
contains all hops, separated by ", ".

We take the first one, i.e. probably the fqdn set by the browser.

See #74.