### PR TITLE
Make the LogFormatter implementations public.

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -185,19 +185,19 @@ func buildCommonLogLine(req *http.Request, url url.URL, ts time.Time, status int
 	return buf
 }
 
-// writeLog writes a log entry for req to w in Apache Common Log Format.
+// WriteLog writes a log entry for req to w in Apache Common Log Format.
 // ts is the timestamp with which the entry should be logged.
 // status and size are used to provide the response HTTP status and size.
-func writeLog(writer io.Writer, params LogFormatterParams) {
+func WriteLog(writer io.Writer, params LogFormatterParams) {
 	buf := buildCommonLogLine(params.Request, params.URL, params.TimeStamp, params.StatusCode, params.Size)
 	buf = append(buf, '\n')
 	writer.Write(buf)
 }
 
-// writeCombinedLog writes a log entry for req to w in Apache Combined Log Format.
+// WriteCombinedLog writes a log entry for req to w in Apache Combined Log Format.
 // ts is the timestamp with which the entry should be logged.
 // status and size are used to provide the response HTTP status and size.
-func writeCombinedLog(writer io.Writer, params LogFormatterParams) {
+func WriteCombinedLog(writer io.Writer, params LogFormatterParams) {
 	buf := buildCommonLogLine(params.Request, params.URL, params.TimeStamp, params.StatusCode, params.Size)
 	buf = append(buf, ` "`...)
 	buf = appendQuoted(buf, params.Request.Referer())
@@ -214,7 +214,7 @@ func writeCombinedLog(writer io.Writer, params LogFormatterParams) {
 //
 // LoggingHandler always sets the ident field of the log to -
 func CombinedLoggingHandler(out io.Writer, h http.Handler) http.Handler {
-	return loggingHandler{out, h, writeCombinedLog}
+	return loggingHandler{out, h, WriteCombinedLog}
 }
 
 // LoggingHandler return a http.Handler that wraps h and logs requests to out in
@@ -234,7 +234,7 @@ func CombinedLoggingHandler(out io.Writer, h http.Handler) http.Handler {
 //  http.ListenAndServe(":1123", loggedRouter)
 //
 func LoggingHandler(out io.Writer, h http.Handler) http.Handler {
-	return loggingHandler{out, h, writeLog}
+	return loggingHandler{out, h, WriteLog}
 }
 
 // CustomLoggingHandler provides a way to supply a custom log formatter

--- a/logging_test.go
+++ b/logging_test.go
@@ -151,18 +151,18 @@ func BenchmarkWriteLog(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		buf.Reset()
-		writeLog(buf, params)
+		WriteLog(buf, params)
 	}
 }
 
 func TestLogFormatterWriteLog_Scenario1(t *testing.T) {
-	formatter := writeLog
+	formatter := WriteLog
 	expected := "192.168.100.5 - - [26/May/1983:03:30:45 +0200] \"GET / HTTP/1.1\" 200 100\n"
 	LoggingScenario1(t, formatter, expected)
 }
 
 func TestLogFormatterCombinedLog_Scenario1(t *testing.T) {
-	formatter := writeCombinedLog
+	formatter := WriteCombinedLog
 	expected := "192.168.100.5 - - [26/May/1983:03:30:45 +0200] \"GET / HTTP/1.1\" 200 100 \"http://example.com\" " +
 		"\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) " +
 		"AppleWebKit/537.33 (KHTML, like Gecko) Chrome/27.0.1430.0 Safari/537.33\"\n"
@@ -170,13 +170,13 @@ func TestLogFormatterCombinedLog_Scenario1(t *testing.T) {
 }
 
 func TestLogFormatterWriteLog_Scenario2(t *testing.T) {
-	formatter := writeLog
+	formatter := WriteLog
 	expected := "192.168.100.5 - - [26/May/1983:03:30:45 +0200] \"CONNECT www.example.com:443 HTTP/2.0\" 200 100\n"
 	LoggingScenario2(t, formatter, expected)
 }
 
 func TestLogFormatterCombinedLog_Scenario2(t *testing.T) {
-	formatter := writeCombinedLog
+	formatter := WriteCombinedLog
 	expected := "192.168.100.5 - - [26/May/1983:03:30:45 +0200] \"CONNECT www.example.com:443 HTTP/2.0\" 200 100 \"http://example.com\" " +
 		"\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) " +
 		"AppleWebKit/537.33 (KHTML, like Gecko) Chrome/27.0.1430.0 Safari/537.33\"\n"
@@ -184,13 +184,13 @@ func TestLogFormatterCombinedLog_Scenario2(t *testing.T) {
 }
 
 func TestLogFormatterWriteLog_Scenario3(t *testing.T) {
-	formatter := writeLog
+	formatter := WriteLog
 	expected := "192.168.100.5 - kamil [26/May/1983:03:30:45 +0200] \"GET / HTTP/1.1\" 401 500\n"
 	LoggingScenario3(t, formatter, expected)
 }
 
 func TestLogFormatterCombinedLog_Scenario3(t *testing.T) {
-	formatter := writeCombinedLog
+	formatter := WriteCombinedLog
 	expected := "192.168.100.5 - kamil [26/May/1983:03:30:45 +0200] \"GET / HTTP/1.1\" 401 500 \"http://example.com\" " +
 		"\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) " +
 		"AppleWebKit/537.33 (KHTML, like Gecko) Chrome/27.0.1430.0 Safari/537.33\"\n"
@@ -198,13 +198,13 @@ func TestLogFormatterCombinedLog_Scenario3(t *testing.T) {
 }
 
 func TestLogFormatterWriteLog_Scenario4(t *testing.T) {
-	formatter := writeLog
+	formatter := WriteLog
 	expected := "192.168.100.5 - - [26/May/1983:03:30:45 +0200] \"GET /test?abc=hello%20world&a=b%3F HTTP/1.1\" 200 100\n"
 	LoggingScenario4(t, formatter, expected)
 }
 
 func TestLogFormatterCombinedLog_Scenario5(t *testing.T) {
-	formatter := writeCombinedLog
+	formatter := WriteCombinedLog
 	expected := "::1 - kamil [26/May/1983:03:30:45 +0200] \"GET / HTTP/1.1\" 200 100 \"http://example.com\" " +
 		"\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) " +
 		"AppleWebKit/537.33 (KHTML, like Gecko) Chrome/27.0.1430.0 Safari/537.33\"\n"


### PR DESCRIPTION
Makes `writeLog` and `writeCombinedLog` public.  This makes is easy to wrap the provided (very useful and complete) formatters with some extra logic to perform conditional logging based on `LogFormatterParams` without having to reimplement the standard formatters.