### PR TITLE
Fix LoggingHandler reporting 0 response size.

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -7,6 +7,7 @@ package handlers
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"sort"
@@ -54,6 +55,12 @@ type responseLogger struct {
 func (l *responseLogger) Write(b []byte) (int, error) {
 	size, err := l.w.Write(b)
 	l.size += size
+	return size, err
+}
+
+func (l *responseLogger) ReadFrom(r io.Reader) (int64, error) {
+	size, err := l.w.(io.ReaderFrom).ReadFrom(r)
+	l.size += int(size)
 	return size, err
 }
 

--- a/logging.go
+++ b/logging.go
@@ -69,6 +69,9 @@ func makeLogger(w http.ResponseWriter) (*responseLogger, http.ResponseWriter) {
 		WriteHeader: func(httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
 			return logger.WriteHeader
 		},
+		ReadFrom: func(httpsnoop.ReadFromFunc) httpsnoop.ReadFromFunc {
+			return logger.ReadFrom
+		},
 	})
 }
 


### PR DESCRIPTION
If you convert your ResponseWriter to an io.ReaderFrom and call ReadFrom to send the response then LoggingHandler reports the size as 0. The cause is a missing ReadFrom hook in responseLogger, similar to the issue fixed in #197.

**Summary of Changes**

1. Add a ReadFrom hook in responseLogger that increments Size.

