### PR TITLE
Toggle and configure default origins. Allow optional runtime function for allowed origins and headers.

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -303,7 +303,6 @@ func filterAllowedOrigins(input []string) []string {
 	for _, v := range input {
 		if v == corsOriginMatchAll {
 			return []string{corsOriginMatchAll}
-			return nil
 		}
 	}
 	return input

--- a/cors.go
+++ b/cors.go
@@ -180,12 +180,12 @@ func CORS(opts ...CORSOption) func(http.Handler) http.Handler {
 
 func parseCORSOptions(opts ...CORSOption) *cors {
 	ch := &cors{
-		allowedMethods:   defaultCorsMethods,
-		allowedHeaders:   defaultCorsHeaders,
-		allowedOrigins:   []string{},
-		optionStatusCode: defaultCorsOptionStatusCode,
+		allowedMethods:      defaultCorsMethods,
+		allowedHeaders:      defaultCorsHeaders,
+		allowedOrigins:      []string{},
+		optionStatusCode:    defaultCorsOptionStatusCode,
 		allowDefaultOrigins: true,
-		defaultOrigin: "*",
+		defaultOrigin:       "*",
 	}
 
 	for _, option := range opts {
@@ -409,7 +409,7 @@ func (ch *cors) isOriginAllowed(r *http.Request, origin string) bool {
 	return false
 }
 
-func (ch *cors) getAllowedOrigins(r *http.Request) [] string {
+func (ch *cors) getAllowedOrigins(r *http.Request) []string {
 	if ch.allowedOriginsFunc != nil {
 		return ch.allowedOriginsFunc(r)
 	} else {

--- a/cors_test.go
+++ b/cors_test.go
@@ -455,22 +455,22 @@ func TestCORSOriginValidatorWithExplicitStar(t *testing.T) {
 		AllowedOriginValidator(originValidator),
 		AllowedOrigins([]string{"*"}),
 	)(testHandler).ServeHTTP(rr, r)
-	header := rr.HeaderMap.Get(corsAllowOriginHeader)
+	header := rr.Header().Get(corsAllowOriginHeader)
 	if got, want := header, "*"; got != want {
 		t.Fatalf("bad header: expected %q to be %q, got %q.", corsAllowOriginHeader, want, got)
 	}
 }
 
-func TestCORSAllowStar(t *testing.T) {
+func TestCORSAllowStarDisallowDefault(t *testing.T) {
 	r := newRequest("GET", "http://a.example.com")
 	r.Header.Set("Origin", r.URL.String())
 	rr := httptest.NewRecorder()
 
 	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 
-	CORS()(testHandler).ServeHTTP(rr, r)
-	header := rr.HeaderMap.Get(corsAllowOriginHeader)
-	if got, want := header, "*"; got != want {
-		t.Fatalf("bad header: expected %q to be %q, got %q.", corsAllowOriginHeader, want, got)
+	CORS(DisallowDefaultOrigins())(testHandler).ServeHTTP(rr, r)
+	header := rr.Header().Get(corsAllowOriginHeader)
+	if header != "" {
+		t.Fatalf("expected header to empty")
 	}
 }

--- a/cors_test.go
+++ b/cors_test.go
@@ -249,6 +249,28 @@ func TestCORSHandlerAllowedHeaderForPreflight(t *testing.T) {
 	}
 }
 
+func TestCORSHandlerAllowedHeaderFuncForPreflight(t *testing.T) {
+	r := newRequest("OPTIONS", "http://www.example.com/")
+	r.Header.Set("Origin", r.URL.String())
+	r.Header.Set(corsRequestMethodHeader, "POST")
+	r.Header.Set(corsRequestHeadersHeader, "Content-Type")
+
+	rr := httptest.NewRecorder()
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	CORS(AllowedHeadersFunc(func() []string { return []string{"Content-Type"} }))(testHandler).ServeHTTP(rr, r)
+
+	if got, want := rr.Code, http.StatusOK; got != want {
+		t.Fatalf("bad status: got %v want %v", got, want)
+	}
+
+	header := rr.HeaderMap.Get(corsAllowHeadersHeader)
+	if got, want := header, "Content-Type"; got != want {
+		t.Fatalf("bad header: expected %q header, got %q header.", want, got)
+	}
+}
+
 func TestCORSHandlerInvalidHeaderForPreflightForbidden(t *testing.T) {
 	r := newRequest("OPTIONS", "http://www.example.com/")
 	r.Header.Set("Origin", r.URL.String())

--- a/cors_test.go
+++ b/cors_test.go
@@ -372,7 +372,7 @@ func TestCORSHandlerMultipleAllowOriginsFunc(t *testing.T) {
 	count := 0
 
 	CORS(AllowedOriginsFunc(func(_r *http.Request) []string {
-		count ++
+		count++
 		if _r != r {
 			t.Fatalf("bad request to origns func status: got %v want %v", _r, r)
 		}


### PR DESCRIPTION
Fixes #

**Summary of Changes**

1. I included  two fields to enable and set the default origins. This allows CORS to be disabled by default.
2. Include optional functions to allow the origins and headers to be set per request. This is helpful for a multi-tenant type application.

> PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!
