### PR TITLE
Allow all cors headers if we pass *(wildcard)

### DIFF
--- a/cors_test.go
+++ b/cors_test.go
@@ -7,6 +7,26 @@ import (
 	"testing"
 )
 
+func TestCORSAllowedHeadersAll(t *testing.T) {
+	r := newRequest("OPTIONS", "http://www.example.com")
+	r.Header.Set("Origin", r.URL.String())
+	r.Header.Set(corsRequestMethodHeader, "GET")
+	r.Header.Set(corsRequestHeadersHeader, "X-Forwarded-For")
+	rr := httptest.NewRecorder()
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	CORS(
+		AllowedHeaders([]string{"*"}),
+		AllowedOrigins([]string{"http://www.example.com"}),
+	)(testHandler).ServeHTTP(rr, r)
+
+	header := rr.Header().Get(corsAllowHeadersHeader)
+	if got, want := header, "*"; got != want {
+		t.Fatalf("bad header: expected %q header, got empty header for method.", want)
+	}
+}
+
 func TestDefaultCORSHandlerReturnsOk(t *testing.T) {
 	r := newRequest("GET", "http://www.example.com/")
 	rr := httptest.NewRecorder()

--- a/cors_test.go
+++ b/cors_test.go
@@ -23,7 +23,7 @@ func TestCORSAllowedHeadersAll(t *testing.T) {
 
 	header := rr.Header().Get(corsAllowHeadersHeader)
 	if got, want := header, "*"; got != want {
-		t.Fatalf("bad header: expected %q header, got empty header for method.", want)
+		t.Fatalf("bad header: expected %q header, got wrong header value.", want)
 	}
 }
 

--- a/handlers_go18_test.go
+++ b/handlers_go18_test.go
@@ -1,3 +1,4 @@
+//go:build go1.8
 // +build go1.8
 
 package handlers


### PR DESCRIPTION
Fixes #210

**Summary of Changes**

1. Add check inside `AllowedHeaders` function to support wildcard `*`
2. Inside `ServeHttp` method add check for `corsHeaderMatchAll`
3. Add test case to validate the dev work

> PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!

cc @elithrar 