### PR TITLE
cors: * treated as literal value when AllowCredentials configures CORS

### DIFF
--- a/cors_test.go
+++ b/cors_test.go
@@ -408,3 +408,37 @@ func TestCORSAllowStar(t *testing.T) {
 		t.Fatalf("bad header: expected %q to be %q, got %q.", corsAllowOriginHeader, want, got)
 	}
 }
+
+func TestCORSHandlerAllowedCredentialsDisallowsStar(t *testing.T) {
+	r := httptest.NewRequest(http.MethodHead, "http://example.com", nil)
+	r.Header.Set("Origin", r.URL.String())
+	rr := httptest.NewRecorder()
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	CORS(
+		AllowCredentials(),
+		AllowedOrigins([]string{"*"}),
+	)(testHandler).ServeHTTP(rr, r)
+	header := rr.HeaderMap.Get(corsAllowOriginHeader)
+	if got, want := header, ""; got != want {
+		t.Fatalf("found header: expected no %s header, got %q.", corsAllowOriginHeader, got)
+	}
+}
+
+func TestCORSHandlerAllowedCredentialsMultipleOriginsWithStarLiteral(t *testing.T) {
+	r := httptest.NewRequest(http.MethodHead, "http://example.com", nil)
+	r.Header.Set("Origin", r.URL.String())
+	rr := httptest.NewRecorder()
+
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+	CORS(
+		AllowCredentials(),
+		AllowedOrigins([]string{r.URL.String(), "*"}),
+	)(testHandler).ServeHTTP(rr, r)
+	header := rr.HeaderMap.Get(corsAllowOriginHeader)
+	if got, want := header, r.URL.String(); got != want {
+		t.Fatalf("bad header: expected %q to be %q, got %q", corsAllowOriginHeader, want, got)
+	}
+}

--- a/handlers_go18_test.go
+++ b/handlers_go18_test.go
@@ -1,3 +1,4 @@
+//go:build go1.8
 // +build go1.8
 
 package handlers


### PR DESCRIPTION
Reference conversation in #210 

**Summary of Changes**

1. When `CORS` is called with `AllowCredentials()` and `AllowedOrigins` includes `"*"`, the wildcard is not treated as such, but is instead treated as a literal value.
2. This impacts both allowing requests and setting values in the `Access-Control-Allow-Origin` header.

**Why**
A future revision should consider calling `AllowCredentials()` and `AllowedOrigins([]string{"*"})` to be an error. The [CORS protocol](https://fetch.spec.whatwg.org/#http-cors-protocol) does not allow for any origin to be accepted when credentials are included in a request ([ref](https://fetch.spec.whatwg.org/#cors-protocol-and-credentials); note, there is some ambiguity here, but this hard stance seems simplest to maintain from my perspective). At the moment, outside `panic`, there's no simple way to expose to the caller that a CORS middleware is badly configured without changing `CORS`'s signature.