### PR TITLE
Replace 200, HEAD and OPTIONS with constants from net/http

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -26,14 +26,14 @@ type cors struct {
 type OriginValidator func(string) bool
 
 var (
-	defaultCorsOptionStatusCode = 200
-	defaultCorsMethods          = []string{http.MethodGet, "HEAD", http.MethodPost}
+	defaultCorsOptionStatusCode = http.StatusOK
+	defaultCorsMethods          = []string{http.MethodGet, http.MethodHead, http.MethodPost}
 	defaultCorsHeaders          = []string{"Accept", "Accept-Language", "Content-Language", "Origin"}
 	// (WebKit/Safari v9 sends the Origin header by default in AJAX requests).
 )
 
 const (
-	corsOptionMethod           string = "OPTIONS"
+	corsOptionMethod           string = http.MethodOptions
 	corsAllowOriginHeader      string = "Access-Control-Allow-Origin"
 	corsExposeHeadersHeader    string = "Access-Control-Expose-Headers"
 	corsMaxAgeHeader           string = "Access-Control-Max-Age"


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

A previous commit (#241) replaced most HTTP constants with those from standard library `net/http`, but some was missed. This PR catches 3 of them.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue: None
- Closes: None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: Trivial changes, tests not required
- [ ] I need help with writing tests

## Run verifications and test

- [ ] `make verify` is passing (which I believe is not my fault)
- [x] `make test` is passing
