### PR TITLE
Add zstd support for compression middleware

### DIFF
--- a/compress_test.go
+++ b/compress_test.go
@@ -126,6 +126,24 @@ func TestAcceptEncodingIsDropped(t *testing.T) {
 	}
 }
 
+func TestCompressHandlerZstd(t *testing.T) {
+	w := httptest.NewRecorder()
+	compressedRequest(w, "zstd")
+	resp := w.Result()
+	if resp.Header.Get("Content-Encoding") != "zstd" {
+		t.Fatalf("wrong content encoding, got %q want %q", resp.Header.Get("Content-Encoding"), "zstd")
+	}
+	if resp.Header.Get("Content-Type") != "text/plain; charset=utf-8" {
+		t.Fatalf("wrong content type, got %s want %s", resp.Header.Get("Content-Type"), "text/plain; charset=utf-8")
+	}
+	if w.Body.Len() != 32 {
+		t.Fatalf("wrong len, got %d want %d", w.Body.Len(), 32)
+	}
+	if l := resp.Header.Get("Content-Length"); l != "" {
+		t.Fatalf("wrong content-length. got %q expected %q", l, "")
+	}
+}
+
 func TestCompressHandlerGzip(t *testing.T) {
 	w := httptest.NewRecorder()
 	compressedRequest(w, "gzip")
@@ -165,6 +183,18 @@ func TestCompressHandlerGzipDeflate(t *testing.T) {
 	resp := w.Result()
 	if resp.Header.Get("Content-Encoding") != "gzip" {
 		t.Fatalf("wrong content encoding, got %q want %q", resp.Header.Get("Content-Encoding"), "gzip")
+	}
+	if resp.Header.Get("Content-Type") != "text/plain; charset=utf-8" {
+		t.Fatalf("wrong content type, got %s want %s", resp.Header.Get("Content-Type"), "text/plain; charset=utf-8")
+	}
+}
+
+func TestCompressHandlerGzipDeflateBrZstd(t *testing.T) {
+	w := httptest.NewRecorder()
+	compressedRequest(w, "gzip, deflate, br, zstd")
+	resp := w.Result()
+	if resp.Header.Get("Content-Encoding") != "zstd" {
+		t.Fatalf("wrong content encoding, got %q want %q", resp.Header.Get("Content-Encoding"), "zstd")
 	}
 	if resp.Header.Get("Content-Type") != "text/plain; charset=utf-8" {
 		t.Fatalf("wrong content type, got %s want %s", resp.Header.Get("Content-Type"), "text/plain; charset=utf-8")

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/gorilla/handlers
 
-go 1.20
+go 1.21
 
 require github.com/felixge/httpsnoop v1.0.3
+
+require github.com/klauspost/compress v1.17.11

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
+github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=

--- a/logging_test.go
+++ b/logging_test.go
@@ -148,7 +148,7 @@ func TestLogUser(t *testing.T) {
 func BenchmarkWriteLog(b *testing.B) {
 	loc, err := time.LoadLocation("Europe/Warsaw")
 	if err != nil {
-		b.Fatalf(err.Error())
+		b.Fatal(err.Error())
 	}
 	ts := time.Date(1983, 0o5, 26, 3, 30, 45, 0, loc)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [x] Go Version Update
- [x] Dependency Update

## Description

Modern browsers now natively support zstandard, a superior compression algorithm from a compression ratio and speed standpoint.

See: https://caniuse.com/zstd

This PR:

- Adds zstd support to compress middleware with github.com/klauspost/compress/zstd
- Prefers zstd over gzip or flate when possible to leverage its superior compression ratios and speed
- Updates documentation and adds unit tests

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [x] `make verify` is passing
- [x] `make test` is passing
