### PR TITLE
Fix typo in cors.go

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -253,7 +253,7 @@ func AllowedOriginValidator(fn OriginValidator) CORSOption {
 }
 
 // OptionStatusCode sets a custom status code on the OPTIONS requests.
-// Default behaviour sets it to 200 to reflect best practices. This is option is not mandatory
+// Default behaviour sets it to 200 to reflect best practices. This option is not mandatory
 // and can be used if you need a custom status code (i.e 204).
 //
 // More informations on the spec:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] Documentation Update

## Description

I came across a typo while going through the code.

## Added/updated tests?

- [X] No, not needed for docs

## Run verifications and test

- [X] `make verify` is passing
- [X] `make test` is passing
